### PR TITLE
Fix test workflow issues with WP_Mock and PHP 7.0 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests - Run PHP compatibility and unit tests
 
 on:
   push:
@@ -27,7 +27,15 @@ jobs:
           tools: composer:v2
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: |
+          if [[ "${{ matrix.php-versions }}" == "7.0" ]]; then
+            composer require --dev phpunit/phpunit:"^6.5" --update-with-dependencies
+            composer require --dev 10up/wp_mock:"^0.4.2" --update-with-dependencies
+            composer require --dev antecedent/patchwork:"^2.1.21" --update-with-dependencies
+          else
+            composer install --prefer-dist --no-progress
+            composer require --dev 10up/wp_mock:"^0.4.2" --update-with-dependencies
+          fi
 
       - name: Run tests
         run: ./vendor/bin/phpunit
@@ -51,4 +59,4 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run PHPCS
-        run: ./vendor/bin/phpcs --standard=WordPress --runtime-set installed_paths vendor/wp-coding-standards/wpcs
+        run: ./vendor/bin/phpcs --standard=WordPress --runtime-set installed_paths vendor/wp-coding-standards/wpcs ./includes ./admin ./wp-plugin-starter-template.php

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,10 @@
 // First, we need to load the composer autoloader so we can use WP Mock.
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
+// Import WP_Mock class
+use WP_Mock\Tools\TestCase;
+use WP_Mock;
+
 // Now call the bootstrap method of WP Mock.
 WP_Mock::bootstrap();
 

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -7,11 +7,13 @@
 
 use WPALLSTARS\PluginStarterTemplate\Admin\Admin;
 use WPALLSTARS\PluginStarterTemplate\Core;
+use WP_Mock\Tools\TestCase;
+use WP_Mock;
 
 /**
  * Admin test case.
  */
-class AdminTest extends WP_Mock\Tools\TestCase {
+class AdminTest extends TestCase {
 
     /**
      * Test instance
@@ -32,19 +34,19 @@ class AdminTest extends WP_Mock\Tools\TestCase {
      */
     public function setUp(): void {
         parent::setUp();
-        
+
         // Set up mocks
         WP_Mock::setUp();
-        
+
         // Mock Core class
         $this->core = $this->createMock(Core::class);
-        
+
         // Set up WordPress function mocks
         WP_Mock::userFunction('add_action', [
             'times' => 1,
             'args' => ['admin_enqueue_scripts', \WP_Mock\Functions::type('array')],
         ]);
-        
+
         // Create instance of Admin class
         $this->admin = new Admin($this->core);
     }
@@ -74,38 +76,38 @@ class AdminTest extends WP_Mock\Tools\TestCase {
             'times' => 1,
             'args' => ['wpst-admin-styles', \WP_Mock\Functions::type('string'), [], \WP_Mock\Functions::type('string')],
         ]);
-        
+
         WP_Mock::userFunction('wp_enqueue_script', [
             'times' => 1,
             'args' => ['wpst-admin-scripts', \WP_Mock\Functions::type('string'), ['jquery'], \WP_Mock\Functions::type('string'), true],
         ]);
-        
+
         WP_Mock::userFunction('wp_localize_script', [
             'times' => 1,
             'args' => ['wpst-admin-scripts', 'wpstData', \WP_Mock\Functions::type('array')],
         ]);
-        
+
         WP_Mock::userFunction('esc_html__', [
             'times' => 2,
             'args' => [\WP_Mock\Functions::type('string'), 'wp-plugin-starter-template'],
             'return' => 'Translated string',
         ]);
-        
+
         WP_Mock::userFunction('admin_url', [
             'times' => 1,
             'args' => ['admin-ajax.php'],
             'return' => 'http://example.org/wp-admin/admin-ajax.php',
         ]);
-        
+
         WP_Mock::userFunction('wp_create_nonce', [
             'times' => 1,
             'args' => ['wpst-admin-nonce'],
             'return' => '1234567890',
         ]);
-        
+
         // Call the method
         $this->admin->enqueue_admin_assets('plugins.php');
-        
+
         // If we get here, the test passed
         $this->assertTrue(true);
     }

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -6,11 +6,13 @@
  */
 
 use WPALLSTARS\PluginStarterTemplate\Core;
+use WP_Mock\Tools\TestCase;
+use WP_Mock;
 
 /**
  * Core test case.
  */
-class CoreTest extends WP_Mock\Tools\TestCase {
+class CoreTest extends TestCase {
 
     /**
      * Test instance
@@ -24,10 +26,10 @@ class CoreTest extends WP_Mock\Tools\TestCase {
      */
     public function setUp(): void {
         parent::setUp();
-        
+
         // Set up mocks
         WP_Mock::setUp();
-        
+
         // Create instance of Core class
         $this->core = new Core();
     }
@@ -53,7 +55,7 @@ class CoreTest extends WP_Mock\Tools\TestCase {
      */
     public function test_filter_content() {
         $content = 'Test content';
-        
+
         // Test that filter_content returns the content
         $this->assertEquals($content, $this->core->filter_content($content));
     }


### PR DESCRIPTION
This PR fixes the remaining test workflow issues:

1. Fixed PHPCS error by specifying files to check (already done in previous PR)
2. Fixed WP_Mock not found error by:
   - Properly importing WP_Mock classes in bootstrap.php
   - Adding proper namespace imports in test files
   - Ensuring 10up/wp_mock is installed correctly
3. Fixed PHP 7.0 compatibility by:
   - Adding antecedent/patchwork dependency for PHP 7.0
   - Ensuring proper version constraints for dependencies

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author