### PR TITLE
fix: namespace mismatch, XSS in showNotice/showMessage, tab indentation

### DIFF
--- a/includes/Multisite/class-multisite.php
+++ b/includes/Multisite/class-multisite.php
@@ -6,10 +6,10 @@
  * Extend this file or create additional classes in this directory
  * to implement multisite features for your plugin.
  *
- * @package WP_Plugin_Starter_Template_For_AI_Coding
+ * @package WPALLSTARS\PluginStarterTemplate
  */
 
-namespace WP_Plugin_Starter_Template_For_AI_Coding\Multisite;
+namespace WPALLSTARS\PluginStarterTemplate\Multisite;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary

Fixes the critical namespace mismatch identified by CodeRabbit review of PR #18, as described in issue #19.

Rebased onto main (resolving merge conflicts) — the XSS fixes, tab indentation fixes, and class-admin.php improvements were already merged to main via other PRs.

## Changes

### Critical — Namespace mismatch (Multisite autoloading broken)

\`includes/Multisite/class-multisite.php\` declared namespace \`WP_Plugin_Starter_Template_For_AI_Coding\Multisite\` but the autoloader expects \`WPALLSTARS\PluginStarterTemplate\\\`. Updated to \`WPALLSTARS\PluginStarterTemplate\Multisite\`.

## Notes on remaining issue items

* **XSS in showNotice / showMessage** — already fixed in main (commits to admin/js/admin-scripts.js and admin/js/update-source-selector.js in prior PRs)
* **Tab indentation in class-admin.php** — already fixed in main
* **PHP 7.0 matrix** — not applicable; the current CI matrix only contains \`7.4\` and \`8.0\`
* **Plugin::init() not called** — already fixed in main
* **PSR-4 filename mismatch** — the autoloader handles WordPress naming convention explicitly, by design

## Verification

* PHPCS passes cleanly on \`includes/Multisite/class-multisite.php\`
* Merge conflict with main resolved by rebase; only the namespace fix remains as a unique change
* PR is now mergeable (was CONFLICTING)

Closes #19