### PR TITLE
fix: disable networking in singleSiteBlueprint (#39)

### DIFF
--- a/playground/test.html
+++ b/playground/test.html
@@ -68,7 +68,7 @@
             "landingPage": "/wp-admin/",
             "login": true,
             "features": {
-                "networking": true
+                "networking": false
             },
             "steps": [
                 {


### PR DESCRIPTION
## Summary

* Sets `networking: false` in `singleSiteBlueprint` in `playground/test.html`
* Prevents the single-site playground environment from inadvertently enabling multisite behaviour
* Addresses CodeRabbit review feedback from PR #15 (high severity finding)

## Change

`playground/test.html:71` — `"networking": true` → `"networking": false`

The `networking` flag in WordPress Playground blueprints controls multisite-related networking features. Enabling it in a single-site blueprint is misleading and can cause unexpected multisite activation.

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled networking features in the singleSite blueprint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->