### PR TITLE
fix(tests): add plugin activation verification by slug (issue #32)

### DIFF
--- a/cypress/e2e/playground-single-site.cy.js
+++ b/cypress/e2e/playground-single-site.cy.js
@@ -18,6 +18,14 @@ describe('WordPress Playground Single Site Tests', () => {
     cy.visit('/wp-admin/plugins.php', { timeout: 30000 });
 
     cy.get('body', { timeout: 15000 }).then(($body) => {
+      // Verify the starter template plugin exists and is activated.
+      if ($body.find('tr[data-slug="wp-plugin-starter-template-for-ai-coding"]').length) {
+        cy.get('tr[data-slug="wp-plugin-starter-template-for-ai-coding"]').should('exist');
+        cy.get('tr[data-slug="wp-plugin-starter-template-for-ai-coding"] .deactivate a').should('exist');
+      } else {
+        cy.log('Starter template plugin not found by slug, skipping check');
+      }
+
       if ($body.text().includes('Plugin Toggle')) {
         cy.contains('tr', 'Plugin Toggle').should('exist');
         cy.contains('tr', 'Plugin Toggle').find('.deactivate').should('exist');


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #15 tracked in issue #32.

* Adds explicit activation check for the starter template plugin (`wp-plugin-starter-template-for-ai-coding`) using its `data-slug` attribute
* Verifies the `.deactivate a` link is present, confirming the plugin is active (not just installed)
* Uses the same defensive conditional pattern as the existing demo-plugin checks to handle environments where the plugin may not be found by slug

## Changes

* `cypress/e2e/playground-single-site.cy.js` — added slug-based existence and activation check before the existing demo-plugin checks

## Issue

Closes #32

## Review feedback addressed

> **CodeRabbit (HIGH)**: The test only checks if the plugin exists in the list but doesn't verify if it's actually activated. Add verification by checking for the 'deactivate' link.