### PR TITLE
t044: fix redundant excludePaths.analyse block in phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,13 +5,6 @@ parameters:
         - admin
         - wp-plugin-starter-template.php
     excludePaths:
-        analyse:
-            - vendor
-            - node_modules
-            - tests
-            - bin
-            - build
-            - dist
         analyseAndScan:
             - vendor
             - node_modules


### PR DESCRIPTION
## Summary

* Removes the redundant `excludePaths.analyse` block from `phpstan.neon`
* Keeps only `excludePaths.analyseAndScan` which is the superset — it excludes paths from both analysis and file scanning, making the `analyse`-only block unnecessary

## Changes

`phpstan.neon`: Consolidated `excludePaths` from two identical blocks (`analyse` + `analyseAndScan`) down to a single `analyseAndScan` block. No functional change — the excluded paths remain the same.

## Review Feedback Addressed

Addresses CodeRabbit findings from PR #13:
* **Finding 1** (`phpstan.neon:14`): Fixed `excludePaths` structure — removed the redundant `analyse` sub-key, keeping only `analyseAndScan`
* **Finding 2** (`phpstan.neon:25`): Already resolved in a prior commit (structure of `ignoreErrors` and `reportUnmatchedIgnoredErrors` indentation)

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the scope of automated code analysis to include additional project directories previously excluded from routine checks. This enhancement increases quality assurance coverage and helps identify potential issues across a larger portion of the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->