### PR TITLE
fix: address bin/install-wp-tests.sh PR #15 review feedback (issue #29)

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -44,14 +44,25 @@ elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
 	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
-	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
-	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//' | head -1)
 	if [[ -z "$LATEST_VERSION" ]]; then
 		echo "Latest WordPress version could not be found"
 		exit 1
 	fi
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
+
+# Derive a git ref from WP_TESTS_TAG by stripping the SVN-style prefix.
+# WP_TESTS_TAG uses "tags/X.Y.Z", "branches/X.Y", or "trunk".
+# git clone --branch requires the bare ref name ("X.Y.Z", "X.Y", or "trunk").
+if [[ "$WP_TESTS_TAG" == tags/* ]]; then
+	GIT_REF="${WP_TESTS_TAG#tags/}"
+elif [[ "$WP_TESTS_TAG" == branches/* ]]; then
+	GIT_REF="${WP_TESTS_TAG#branches/}"
+else
+	GIT_REF="$WP_TESTS_TAG"
+fi
+
 set -ex
 
 install_wp() {
@@ -106,8 +117,8 @@ install_test_suite() {
 	# set up testing suite if it doesn't yet exist
 	if [ ! -d "$WP_TESTS_DIR" ]; then
 		mkdir -p "$WP_TESTS_DIR"
-		if ! git clone --quiet --depth=1 --branch "$WP_TESTS_TAG" https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-develop; then
-			echo "Error: Failed to clone wordpress-develop at branch/tag $WP_TESTS_TAG" >&2
+		if ! git clone --quiet --depth=1 --branch "$GIT_REF" https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-develop; then
+			echo "Error: Failed to clone wordpress-develop at branch/tag $GIT_REF" >&2
 			exit 1
 		fi
 		if [ -d /tmp/wordpress-develop/tests/phpunit/includes ]; then


### PR DESCRIPTION
## Summary

Addresses all 4 CodeRabbit findings from PR #15 review on `bin/install-wp-tests.sh` (tracked as quality-debt issue #29).

## Changes

### HIGH: Harden `download()` function
- Replace `which` with `command -v >/dev/null 2>&1` (POSIX-safe)
- Use `curl -fsSL "$1" -o "$2"` (fail-fast, silent, follow redirects)
- Use `wget -qO "$2" "$1"` (quiet, correct argument order)
- Add `else` branch: exit with error if neither curl nor wget is available

### MEDIUM: Fix beta/RC version tag logic
- The beta/RC block set `WP_BRANCH` but never assigned `WP_TESTS_TAG`, so the computed branch was silently discarded
- Added `WP_TESTS_TAG="branches/$WP_BRANCH"` to complete the assignment

### MEDIUM: Use `WP_TESTS_TAG` in `git clone` (CI fix)
- `WP_TESTS_TAG` uses SVN-style paths (`tags/X.Y.Z`, `branches/X.Y`, `trunk`)
- `git clone --branch` requires bare ref names (`X.Y.Z`, `X.Y`, `trunk`)
- Derive `GIT_REF` by stripping the `tags/` or `branches/` prefix before passing to `git clone`
- This fixes the CI failure: `fatal: Remote branch tags/6.9.4 not found in upstream origin`

### MEDIUM: Add failure checks in `install_test_suite`
- `git clone` and `cp` operations now use `if ! cmd; then ... exit 1; fi` pattern
- Errors produce a descriptive message to stderr before exiting

### Additional fixes
- Remove no-op `grep` line in latest version lookup (was using ERE syntax without `-E`)
- Add `head -1` to version grep to guard against multiple matches
- Quote `$ioption` in all `sed` calls (SC2046/word splitting)
- Replace `sed "s:/\+$::"` with `${WP_CORE_DIR%/}` (SC2001)
- Quote `${SKIP_DB_CREATE}` and `$EXTRA` (SC2086)
- Suppress SC2001 for `VERSION_ESCAPED` sed (regex dot-escaping requires sed)

## Verification

```
shellcheck bin/install-wp-tests.sh
# Exit: 0 (zero violations)
```

Closes #29