### PR TITLE
fix: address PR #9 review feedback quality-debt (#46)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,7 @@
 {
+  "MD004": {
+    "style": "asterisk"
+  },
   "MD012": false,
   "MD022": false,
   "MD031": false,

--- a/.wiki/Coding-Standards.md
+++ b/.wiki/Coding-Standards.md
@@ -67,7 +67,7 @@ if ($condition) {
 ### Documentation
 
 * All classes, methods, and functions should be documented using PHPDoc
-* Include a description, parameters, return values, and exceptions
+* Include a description of the parameters, return values, and possible exceptions
 
 ```php
 /**

--- a/.wiki/Contributing.md
+++ b/.wiki/Contributing.md
@@ -6,11 +6,11 @@ Thank you for considering contributing to this project! This document provides g
 
 By participating in this project, you agree to abide by our code of conduct:
 
-- Be respectful and inclusive
-- Be patient and welcoming
-- Be considerate
-- Be collaborative
-- Be open-minded
+* Be respectful and inclusive
+* Be patient and welcoming
+* Be considerate
+* Be collaborative
+* Be open-minded
 
 ## How to Contribute
 
@@ -26,12 +26,12 @@ If you find a bug, please report it by creating an issue on GitHub:
 
 Please include:
 
-- A clear, descriptive title
-- Steps to reproduce the bug
-- Expected behavior
-- Actual behavior
-- Screenshots (if applicable)
-- Your environment (WordPress version, PHP version, browser, etc.)
+* A clear, descriptive title
+* Steps to reproduce the bug
+* Expected behavior
+* Actual behavior
+* Screenshots (if applicable)
+* Your environment (WordPress version, PHP version, browser, etc.)
 
 ### Suggesting Enhancements
 
@@ -45,10 +45,10 @@ If you have an idea for an enhancement:
 
 Please include:
 
-- A clear, descriptive title
-- A detailed description of the enhancement
-- Why this enhancement would be useful
-- Any relevant examples or mockups
+* A clear, descriptive title
+* A detailed description of the enhancement
+* Why this enhancement would be useful
+* Any relevant examples or mockups
 
 ### Pull Requests
 
@@ -72,33 +72,33 @@ If you want to contribute code:
 
 #### Pull Request Guidelines
 
-- Follow the coding standards (see [Coding Standards](Coding-Standards))
-- Write tests for your changes
-- Update documentation as needed
-- Keep pull requests focused on a single change
-- Write a clear, descriptive title and description
-- Reference any related issues
-- Ensure your code passes the automated code quality checks (see below)
+* Follow the coding standards (see [Coding Standards](Coding-Standards))
+* Write tests for your changes
+* Update documentation as needed
+* Keep pull requests focused on a single change
+* Write a clear, descriptive title and description
+* Reference any related issues
+* Ensure your code passes the automated code quality checks (see below)
 
 #### Code Quality Tools
 
 This project uses several automated code quality tools to ensure high standards. These tools are free for public repositories and will automatically analyze your code when you create a pull request:
 
 1. **CodeRabbit**: AI-powered code review tool
-   - [Website](https://www.coderabbit.ai/)
-   - Provides automated feedback on pull requests
+   * [Website](https://www.coderabbit.ai/)
+   * Provides automated feedback on pull requests
 
 2. **CodeFactor**: Continuous code quality monitoring
-   - [Website](https://www.codefactor.io/)
-   - Provides a grade for your codebase
+   * [Website](https://www.codefactor.io/)
+   * Provides a grade for your codebase
 
 3. **Codacy**: Code quality and static analysis
-   - [Website](https://www.codacy.com/)
-   - Identifies issues related to code style, security, and performance
+   * [Website](https://www.codacy.com/)
+   * Identifies issues related to code style, security, and performance
 
 4. **SonarCloud**: Code quality and security analysis
-   - [Website](https://sonarcloud.io/)
-   - Provides detailed analysis of code quality and security
+   * [Website](https://sonarcloud.io/)
+   * Provides detailed analysis of code quality and security
 
 #### Using AI Assistants with Code Quality Tools
 

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
+set -euo pipefail
 
 # WordPress Plugin Build Script
 # This script creates a clean build of the plugin for distribution
 
 # Check if version is provided
 if [ -z "$1" ]; then
-    echo "❌ Error: Version number is required"
-    echo "Usage: ./build.sh <version>"
-    exit 1
+	echo "❌ Error: Version number is required"
+	echo "Usage: ./build.sh <version>"
+	exit 1
 fi
 
 VERSION=$1
@@ -22,15 +23,15 @@ mkdir -p "$BUILD_DIR"
 
 # Run code quality checks
 echo "Running code quality checks..."
-if command -v composer &> /dev/null; then
-    echo "Running PHPCS..."
-    composer run phpcs || { echo "⚠️ PHPCS found issues. Consider running 'composer run phpcbf' to fix them."; }
+if command -v composer &>/dev/null; then
+	echo "Running PHPCS..."
+	composer run phpcs || { echo "⚠️ PHPCS found issues. Consider running 'composer run phpcbf' to fix them."; }
 
-    # Uncomment the following line to automatically fix coding standards issues
-    # echo "Running PHPCBF..."
-    # composer run phpcbf
+	# Uncomment the following line to automatically fix coding standards issues
+	# echo "Running PHPCBF..."
+	# composer run phpcbf
 else
-    echo "⚠️ Composer not found, skipping code quality checks"
+	echo "⚠️ Composer not found, skipping code quality checks"
 fi
 
 # Install composer dependencies
@@ -39,7 +40,7 @@ composer install --no-dev --optimize-autoloader
 
 # Copy plugin files to build directory
 echo "Copying plugin files..."
-cp -R *.php "$BUILD_DIR/"
+cp -R ./*.php "$BUILD_DIR/"
 cp -R README.md LICENSE CHANGELOG.md readme.txt composer.json "$BUILD_DIR/"
 
 # Copy directories
@@ -54,57 +55,57 @@ mkdir -p "$BUILD_DIR/assets/banner" "$BUILD_DIR/assets/icon" "$BUILD_DIR/assets/
 
 # Copy assets if they exist
 if [ -d "assets/banner" ]; then
-    cp -R assets/banner/* "$BUILD_DIR/assets/banner/"
+	cp -R assets/banner/* "$BUILD_DIR/assets/banner/"
 fi
 
 if [ -d "assets/icon" ]; then
-    cp -R assets/icon/* "$BUILD_DIR/assets/icon/"
+	cp -R assets/icon/* "$BUILD_DIR/assets/icon/"
 fi
 
 if [ -d "assets/screenshots" ]; then
-    cp -R assets/screenshots/* "$BUILD_DIR/assets/screenshots/"
+	cp -R assets/screenshots/* "$BUILD_DIR/assets/screenshots/"
 fi
 
 # Copy vendor directory if it exists
 if [ -d "vendor" ]; then
-    cp -R vendor "$BUILD_DIR/"
+	cp -R vendor "$BUILD_DIR/"
 fi
 
 # Create ZIP file
 echo "Creating ZIP file..."
-cd build
+cd build || exit 1
 zip -r "../$ZIP_FILE" "$PLUGIN_SLUG" -x "*.DS_Store" -x "*.git*" -x "*.github*"
 cd ..
 
 # Check if ZIP file was created successfully
 if [ -f "$ZIP_FILE" ]; then
-    echo "✅ Build successful: $ZIP_FILE created"
-    echo "File path: $(pwd)/$ZIP_FILE"
+	echo "✅ Build successful: $ZIP_FILE created"
+	echo "File path: $(pwd)/$ZIP_FILE"
 
-    # Deploy to local WordPress installation if environment variable is set
-    if [ -n "$WP_LOCAL_PLUGIN_DIR" ]; then
-        echo "\nDeploying to local WordPress installation..."
-        echo "Deploying to local WordPress installation..."
+	# Deploy to local WordPress installation if environment variable is set
+	if [ -n "$WP_LOCAL_PLUGIN_DIR" ]; then
+		printf '\nDeploying to local WordPress installation...\n'
+		echo "Deploying to local WordPress installation..."
 
-        # Remove existing plugin directory
-        rm -rf "$WP_LOCAL_PLUGIN_DIR/$PLUGIN_SLUG"
+		# Remove existing plugin directory
+		rm -rf "${WP_LOCAL_PLUGIN_DIR:?}/$PLUGIN_SLUG"
 
-        # Copy files to local WordPress installation
-        rsync -av --exclude=".git" --exclude=".github" --exclude=".DS_Store" \
-            "$BUILD_DIR/" "$WP_LOCAL_PLUGIN_DIR/$PLUGIN_SLUG"
+		# Copy files to local WordPress installation
+		rsync -av --exclude=".git" --exclude=".github" --exclude=".DS_Store" \
+			"$BUILD_DIR/" "$WP_LOCAL_PLUGIN_DIR/$PLUGIN_SLUG"
 
-        # Clear WordPress transients if WP-CLI is available
-        if command -v wp &> /dev/null; then
-            echo "Clearing WordPress transients..."
-            wp transient delete --all --path="$WP_LOCAL_PLUGIN_DIR/../.."
-        else
-            echo "⚠️ WP-CLI not found, skipping transient clearing"
-        fi
+		# Clear WordPress transients if WP-CLI is available
+		if command -v wp &>/dev/null; then
+			echo "Clearing WordPress transients..."
+			wp transient delete --all --path="$WP_LOCAL_PLUGIN_DIR/../.."
+		else
+			echo "⚠️ WP-CLI not found, skipping transient clearing"
+		fi
 
-        echo "✅ Local deployment successful!"
-        echo "Plugin deployed to: $WP_LOCAL_PLUGIN_DIR/$PLUGIN_SLUG"
-    fi
+		echo "✅ Local deployment successful!"
+		echo "Plugin deployed to: $WP_LOCAL_PLUGIN_DIR/$PLUGIN_SLUG"
+	fi
 else
-    echo "❌ Build failed: ZIP file was not created"
-    exit 1
+	echo "❌ Build failed: ZIP file was not created"
+	exit 1
 fi


### PR DESCRIPTION
## Summary

Addresses all actionable findings from the CodeRabbit review of PR #9.

## Changes

* **`.markdownlint.json`**: Added `MD004: {style: asterisk}` to enforce project convention (asterisks for all unordered lists) — previously the config had no explicit style, defaulting to "consistent" which flagged asterisks when dashes appeared first in a file.
* **`.wiki/Contributing.md`**: Converted all dash (`-`) list markers to asterisks (`*`) to comply with MD004 and project AGENTS.md conventions.
* **`.wiki/Coding-Standards.md`**: Fixed PHPDoc bullet wording — "Include a description, parameters..." → "Include a description of the parameters, return values, and possible exceptions" (adds missing preposition, per LanguageTool finding).
* **`build.sh`**: Applied all ShellCheck fixes:
  * Added `set -euo pipefail` for strict error handling (SC2039/reviewer suggestion)
  * Fixed SC2115: `rm -rf "${WP_LOCAL_PLUGIN_DIR:?}/$PLUGIN_SLUG"` to prevent accidental `rm -rf /`
  * Fixed SC2164: `cd build || exit 1` to handle cd failure
  * Fixed SC2028: replaced `echo "\n..."` with `printf '\n...\n'` for portable escape sequences
  * Fixed SC2035: `./*.php` glob to avoid files with leading dashes

## Verification

* `shellcheck build.sh` — zero violations
* `npx markdownlint-cli2 .wiki/Contributing.md .wiki/Coding-Standards.md README.md` — MD004 violations resolved (remaining MD013 line-length errors are pre-existing and out of scope)

Closes #46