### PR TITLE
fix: correct git clone --branch ref format in install-wp-tests.sh

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -17,11 +17,11 @@ WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
 
 download() {
-    if command -v curl > /dev/null; then
-        curl -s "$1" > "$2";
-    elif command -v wget > /dev/null; then
-        wget -nv -O "$2" "$1"
-    fi
+	if command -v curl >/dev/null; then
+		curl -s "$1" >"$2"
+	elif command -v wget >/dev/null; then
+		wget -nv -O "$2" "$1"
+	fi
 }
 
 if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
@@ -53,14 +53,14 @@ set -ex
 install_wp() {
 
 	if [ -d "$WP_CORE_DIR" ]; then
-		return;
+		return
 	fi
 
 	mkdir -p "$WP_CORE_DIR"
 
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 		mkdir -p "$WP_CORE_DIR"
-		download https://wordpress.org/nightly-builds/wordpress-latest.zip  "$WP_CORE_DIR/wordpress-nightly.zip"
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip "$WP_CORE_DIR/wordpress-nightly.zip"
 		unzip -q "$WP_CORE_DIR/wordpress-nightly.zip" -d "$WP_CORE_DIR"
 		rm "$WP_CORE_DIR/wordpress-nightly.zip"
 	else
@@ -82,7 +82,7 @@ install_wp() {
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi
-		download https://wordpress.org/"${ARCHIVE_NAME}".tar.gz  "$WP_CORE_DIR/wordpress.tar.gz"
+		download https://wordpress.org/"${ARCHIVE_NAME}".tar.gz "$WP_CORE_DIR/wordpress.tar.gz"
 		tar --strip-components=1 -zxmf "$WP_CORE_DIR/wordpress.tar.gz" -C "$WP_CORE_DIR"
 		rm "$WP_CORE_DIR/wordpress.tar.gz"
 	fi
@@ -101,7 +101,22 @@ install_test_suite() {
 	# set up testing suite if it doesn't yet exist
 	if [ ! -d "$WP_TESTS_DIR" ]; then
 		mkdir -p "$WP_TESTS_DIR"
-		git clone --quiet --depth=1 https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-develop
+
+		# Convert SVN-style WP_TESTS_TAG (e.g. tags/6.9.4, branches/6.7, trunk)
+		# to a git clone --branch ref (e.g. 6.9.4, 6.7, trunk).
+		local git_clone_ref
+		case "$WP_TESTS_TAG" in
+		tags/*) git_clone_ref="${WP_TESTS_TAG#tags/}" ;;
+		branches/*) git_clone_ref="${WP_TESTS_TAG#branches/}" ;;
+		*) git_clone_ref="$WP_TESTS_TAG" ;;
+		esac
+
+		# Clone at the specific ref; fall back to trunk if the ref is not found.
+		if ! git clone --quiet --depth=1 --branch "$git_clone_ref" https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-develop 2>/dev/null; then
+			echo "Warning: Could not clone wordpress-develop at ref '$git_clone_ref', falling back to trunk" >&2
+			git clone --quiet --depth=1 --branch trunk https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-develop
+		fi
+
 		if [ -d /tmp/wordpress-develop/tests/phpunit/includes ]; then
 			cp -r /tmp/wordpress-develop/tests/phpunit/includes "$WP_TESTS_DIR/"
 		fi
@@ -137,17 +152,17 @@ install_db() {
 	fi
 
 	local PARTS
-	IFS=':' read -ra PARTS <<< "$DB_HOST"
-	local DB_HOSTNAME=${PARTS[0]};
-	local DB_SOCK_OR_PORT=${PARTS[1]};
+	IFS=':' read -ra PARTS <<<"$DB_HOST"
+	local DB_HOSTNAME=${PARTS[0]}
+	local DB_SOCK_OR_PORT=${PARTS[1]}
 	local EXTRA=""
 
-	if [ -n "$DB_HOSTNAME" ] ; then
+	if [ -n "$DB_HOSTNAME" ]; then
 		if [[ $DB_SOCK_OR_PORT =~ ^[0-9]+$ ]]; then
 			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
-		elif [ -n "$DB_SOCK_OR_PORT" ] ; then
+		elif [ -n "$DB_SOCK_OR_PORT" ]; then
 			EXTRA=" --socket=$DB_SOCK_OR_PORT"
-		elif [ -n "$DB_HOSTNAME" ] ; then
+		elif [ -n "$DB_HOSTNAME" ]; then
 			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
 		fi
 	fi


### PR DESCRIPTION
## Summary

Fixes `bin/install-wp-tests.sh` failing with `fatal: Remote branch tags/6.9.4 not found in upstream origin` on the PHP 7.4 WP latest CI matrix.

## Root Cause

The `install_test_suite()` function was cloning `wordpress-develop` without a `--branch` flag, always pulling `trunk`. A previous quality-debt fix (PR #54) added `--branch "$WP_TESTS_TAG"` but `WP_TESTS_TAG` uses SVN-style paths (`tags/6.9.4`, `branches/6.7`) which are not valid `git clone --branch` refs — git clone expects just the tag/branch name (`6.9.4`, `6.7`).

## Fix

* Convert SVN-style `WP_TESTS_TAG` to a plain git ref before passing to `git clone --branch`:
  * `tags/6.9.4` → `6.9.4`
  * `branches/6.7` → `6.7`
  * `trunk` → `trunk` (unchanged)
* Add a `trunk` fallback: if the specific ref clone fails (e.g. a future version not yet tagged), warn and fall back to `trunk` instead of hard-failing CI.

## Testing

* `shellcheck bin/install-wp-tests.sh` — no new violations
* Logic trace for `WP_VERSION=latest`: API returns `6.9.4` → `WP_TESTS_TAG=tags/6.9.4` → `git_clone_ref=6.9.4` → `git clone --branch 6.9.4` succeeds (tag exists in wordpress-develop)

Closes #56