### PR TITLE
fix: add specific plugin functionality tests to single-site.cy.js (issue #33)

### DIFF
--- a/cypress/e2e/single-site.cy.js
+++ b/cypress/e2e/single-site.cy.js
@@ -1,30 +1,75 @@
-describe('WordPress Single Site Tests', () => {
-  it('Can access the site', () => {
-    cy.visit('/');
-    cy.get('body').should('exist');
-  });
+/* eslint-env mocha, jquery, cypress */
+describe( 'WordPress Single Site Tests', () => {
+    it( 'Can access the site', () => {
+        cy.visit( '/' );
+        cy.get( 'body' ).should( 'exist' );
+    } );
 
-  it('Can login to the admin area', () => {
-    cy.loginAsAdmin();
-    cy.get('#wpadminbar').should('exist');
-    cy.get('#dashboard-widgets').should('exist');
-  });
+    it( 'Can login to the admin area', () => {
+        cy.loginAsAdmin();
+        cy.get( '#wpadminbar' ).should( 'exist' );
+        cy.get( '#dashboard-widgets' ).should( 'exist' );
+    } );
 
-  it('Plugin is activated', () => {
-    // Use our custom command to check and activate the plugin if needed
-    cy.activatePlugin('wp-plugin-starter-template-for-ai-coding');
+    it( 'Plugin is activated', () => {
+        // Use our custom command to check and activate the plugin if needed.
+        cy.activatePlugin( 'wp-plugin-starter-template-for-ai-coding' );
 
-    // Verify it's active
-    cy.get('tr[data-slug="wp-plugin-starter-template-for-ai-coding"] .deactivate').should('exist');
-  });
+        // Verify it's active.
+        cy.get( 'tr[data-slug="wp-plugin-starter-template-for-ai-coding"] .deactivate' ).should( 'exist' );
+    } );
 
-  it('Plugin settings page loads correctly', () => {
-    cy.loginAsAdmin();
+    it( 'Plugin row is visible on the plugins page', () => {
+        cy.loginAsAdmin();
+        cy.visit( '/wp-admin/plugins.php' );
 
-    // Navigate to the plugin settings page (if it exists)
-    cy.visit('/wp-admin/options-general.php?page=wp-plugin-starter-template');
+        // Verify the plugin row exists with the correct slug.
+        cy.get( 'tr[data-slug="wp-plugin-starter-template-for-ai-coding"]' ).should( 'exist' );
 
-    // This is a basic check - adjust based on your actual plugin's settings page
-    cy.get('h1').should('contain', 'WP Plugin Starter Template');
-  });
-});
+        // Verify the plugin name is displayed.
+        cy.get( 'tr[data-slug="wp-plugin-starter-template-for-ai-coding"] .plugin-title strong' )
+            .should( 'contain', 'WordPress Plugin Starter Template' );
+    } );
+
+    it( 'Update source selector link is present in the plugin row', () => {
+        cy.loginAsAdmin();
+        cy.visit( '/wp-admin/plugins.php' );
+
+        // The update source selector link should be rendered in the plugin row.
+        cy.get( 'tr[data-slug="wp-plugin-starter-template-for-ai-coding"]' )
+            .find( '.wpst-update-source-selector' )
+            .should( 'exist' );
+    } );
+
+    it( 'Update source modal opens and displays source options', () => {
+        cy.loginAsAdmin();
+        cy.visit( '/wp-admin/plugins.php' );
+
+        // Click the update source selector link to open the modal.
+        cy.get( '.wpst-update-source-selector' ).first().click();
+
+        // Modal should be visible.
+        cy.get( '#wpst-update-source-modal' ).should( 'be.visible' );
+
+        // Modal should contain the three update source options.
+        cy.get( '#wpst-update-source-modal input[name="update_source"][value="wordpress.org"]' ).should( 'exist' );
+        cy.get( '#wpst-update-source-modal input[name="update_source"][value="github"]' ).should( 'exist' );
+        cy.get( '#wpst-update-source-modal input[name="update_source"][value="gitea"]' ).should( 'exist' );
+
+        // Save button should be present.
+        cy.get( '#wpst-save-source' ).should( 'exist' );
+    } );
+
+    it( 'Update source modal can be closed', () => {
+        cy.loginAsAdmin();
+        cy.visit( '/wp-admin/plugins.php' );
+
+        // Open the modal.
+        cy.get( '.wpst-update-source-selector' ).first().click();
+        cy.get( '#wpst-update-source-modal' ).should( 'be.visible' );
+
+        // Close the modal via the close button.
+        cy.get( '#wpst-update-source-modal .wpst-modal-close' ).click();
+        cy.get( '#wpst-update-source-modal' ).should( 'not.be.visible' );
+    } );
+} );


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #15 (issue #33): the previous `single-site.cy.js` only verified plugin activation and included a stub settings-page test that visited a non-existent page with the wrong slug.

## Changes

* Replaced the generic settings-page stub with tests that verify actual plugin functionality.
* Added test: **Plugin row is visible on the plugins page** — confirms the plugin row exists and displays the correct name.
* Added test: **Update source selector link is present in the plugin row** — verifies the `.wpst-update-source-selector` element is rendered (the plugin's primary UI feature).
* Added test: **Update source modal opens and displays source options** — opens the modal and asserts all three source options (`wordpress.org`, `github`, `gitea`) and the Save button are present.
* Added test: **Update source modal can be closed** — clicks the close button and asserts the modal is hidden.
* Added `/* eslint-env mocha, jquery, cypress */` header consistent with `playground-single-site.cy.js`.

## Why these tests

The plugin's actual functionality at this stage is the update source selector modal. Testing that feature end-to-end is more valuable than a settings-page stub that would always 404.

Closes #33