### PR TITLE
fix: resolve ESLint sourceType mismatch for cypress.config.js (issue #31)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,19 @@ module.exports = {
     'no-console': 'warn',
     'no-unused-vars': 'warn'
   },
+  overrides: [
+    {
+      // cypress.config.js uses CommonJS (require/module.exports).
+      // Override sourceType to 'script' so ESLint does not flag require as undefined.
+      files: ['cypress.config.js', 'cypress.config.cjs'],
+      parserOptions: {
+        sourceType: 'script'
+      },
+      env: {
+        node: true
+      }
+    }
+  ],
   globals: {
     cy: 'readonly',
     Cypress: 'readonly',


### PR DESCRIPTION
## Summary

Fixes the \`'require' is not defined\` ESLint/Codacy/CodeFactor error on \`cypress.config.js\`.

## Root Cause

\`.eslintrc.js\` sets \`parserOptions.sourceType: 'module'\` globally, which tells ESLint to parse all files as ESM. In ESM scope, \`require\` and \`module.exports\` are not defined — hence the linter error. The inline \`/* eslint-env node, mocha */\` comment in \`cypress.config.js\` adds the \`node\` environment but **cannot override \`sourceType\`** (a parser-level setting).

The project has no \`"type": "module"\` in \`package.json\`, so CommonJS is the correct module system. \`cypress.config.js\` using \`require\`/\`module.exports\` is correct.

## Fix

Added an \`overrides\` block in \`.eslintrc.js\` that targets \`cypress.config.js\` (and \`cypress.config.cjs\` for future-proofing) and sets \`sourceType: 'script'\`, which is ESLint's term for CommonJS/non-module parsing:

\`\`\`js
overrides: [
  {
    files: ['cypress.config.js', 'cypress.config.cjs'],
    parserOptions: { sourceType: 'script' },
    env: { node: true }
  }
]
\`\`\`

This is the correct approach per ESLint docs on overrides — no rename needed, no project-wide sourceType change.

## Alternatives Considered

* **Rename to \`cypress.config.cjs\`** — would work but is an unnecessary rename; the project is not ESM
* **Convert to ESM** — would require adding \`"type": "module"\` to \`package.json\` and converting all other CJS files; disproportionate change for a config file
* **Disable the rule inline** — suppresses the symptom, not the cause

Closes #31