### PR TITLE
fix: add comma-dangle rule to .eslintrc.js to prevent trailing commas (issue #25)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     sourceType: 'module'
   },
   rules: {
+    'comma-dangle': ['error', 'never'],
     'no-console': 'warn',
     'no-unused-vars': 'warn'
   },


### PR DESCRIPTION
## Summary

Addresses the Codacy review findings from PR #15 that flagged 5 medium-severity ErrorProne issues in `.eslintrc.js` — all related to trailing commas in object/array literals.

## Changes

* Add `'comma-dangle': ['error', 'never']` rule to `.eslintrc.js` rules section

## Why

The trailing commas flagged by Codacy have already been removed from the file. However, without an explicit ESLint rule enforcing this, there's nothing preventing them from being re-introduced. Adding the `comma-dangle: ['error', 'never']` rule makes ESLint itself enforce the no-trailing-commas policy during `npm run lint:js`, catching violations automatically in CI before they reach review.

## Verification

* `npm run lint:js` — passes with no errors or warnings

Closes #25