### PR TITLE
fix: address playground/index.html PR #15 review feedback (issue #36)

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -21,6 +21,6 @@
     </style>
 </head>
 <body>
-    <iframe src="https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wpallstars/wp-plugin-starter-template-for-ai-coding/main/playground/blueprint.json&_t=2" title="WordPress Playground Single Site Environment"></iframe>
+    <iframe src="https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wpallstars/wp-plugin-starter-template-for-ai-coding/main/playground/blueprint.json" title="WordPress Playground Single Site Environment"></iframe>
 </body>
 </html>


### PR DESCRIPTION
## Summary

* Verifies the blueprint URL branch fix for \`playground/index.html\` (updated from \`feature/testing-framework\` to \`main\` in commit f48276c during PR #15 review cycle)
* Removes the stale \`_t=2\` cache-busting query parameter from the blueprint URL — this parameter was added during development and is no longer needed now that the URL points to the stable \`main\` branch

## Changes

* \`playground/index.html\` — Removed the \`&_t=2\` cache-busting parameter from the WordPress Playground iframe \`src\` URL; blueprint URL now cleanly references the canonical \`main\` branch path: \`https://raw.githubusercontent.com/wpallstars/wp-plugin-starter-template-for-ai-coding/main/playground/blueprint.json\`

## Quality Checks

* Blueprint URL correctly references the \`main\` branch (CodeRabbit finding addressed)
* Cache-busting parameter removed — URL is now clean and stable
* PHPCS: No PHP files modified
* HTML structure: Valid, iframe has accessible \`title\` attribute

## Background

CodeRabbit reviewed PR #15 and flagged that \`playground/index.html:23\` had an iframe \`src\` pointing to the \`feature/testing-framework\` branch, which would 404 once the PR was merged. The URL fix was applied in commit f48276c. This PR formally closes the quality-debt tracking issue #36 and also removes the leftover cache-busting parameter from the same URL.

Closes #36