### PR TITLE
fix: use standard max-width media query syntax in admin-styles.css (issue #43)

### DIFF
--- a/admin/css/admin-styles.css
+++ b/admin/css/admin-styles.css
@@ -124,7 +124,7 @@
 }
 
 /* Responsive Styles */
-@media screen and (width <= 782px) {
+@media screen and (max-width: 782px) {
     .wpst-form-table th {
         width: 100%;
         display: block;


### PR DESCRIPTION
## Summary

Fixes #43 — invalid CSS media-feature range syntax flagged in PR #13 review feedback.

## Changes

* `admin/css/admin-styles.css:127`: Replace `(width <= 782px)` with `(max-width: 782px)`

## Why

The range notation `(width <= 782px)` is part of the CSS Media Queries Level 4 spec and is not supported in older browsers (notably Safari < 16.4, Firefox < 63, Chrome < 113). The traditional `max-width` syntax is universally supported and ensures responsive styles work across all target browsers.

## Testing

The responsive breakpoint at 782px (WordPress mobile admin breakpoint) now uses syntax that is compatible with all supported browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved responsive layout behaviour on narrow viewports. Form table elements now properly stack and inputs expand to full width on smaller screens, ensuring better usability across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->