### PR TITLE
quality-debt: t072 — mention both WP-CLI network activation commands

### DIFF
--- a/.wiki/Playground-Testing.md
+++ b/.wiki/Playground-Testing.md
@@ -102,7 +102,7 @@ In a WordPress multisite environment, there are two ways to activate plugins:
 1. **Network Activation**: Activates a plugin for all sites in the network
    * In the WordPress admin, go to Network Admin > Plugins
    * Click "Network Activate" under the plugin
-   * Or use WP-CLI: `wp plugin activate plugin-name --network`
+   * Or use WP-CLI: `wp plugin activate plugin-name --network` (for installed plugins), or `wp plugin install plugin-name --activate-network` (to install and activate)
 
 2. **Per-Site Activation**: Activates a plugin for a specific site
    * In the WordPress admin, go to the specific site's admin area


### PR DESCRIPTION
## Summary

* Documents both WP-CLI commands for network-activating plugins in a multisite environment in `.wiki/Playground-Testing.md`
* `wp plugin activate plugin-name --network` — for plugins already installed
* `wp plugin install plugin-name --activate-network` — to install and network-activate in a single step

## Changes

* `.wiki/Playground-Testing.md` line 105: expanded the WP-CLI example to cover both use cases with brief explanations

## Review Feedback Addressed

Addresses the medium-severity finding from gemini-code-assist on PR #63 (`discussion_r2943520707`): the original edit removed `--activate-network` without noting it is still a valid flag for `wp plugin install`. Both commands are now documented with their respective use cases.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Playground Testing documentation with additional WP-CLI guidance for network activation scenarios. Documentation now provides conditional command pathways for installers, specifically addressing both cases where plugins are already installed and where initial installation is needed first. This delivers improved flexibility and clearer instructions for multisite network deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->