### PR TITLE
fix: remove stale /tmp/wordpress-develop before git clone

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -117,6 +117,7 @@ install_test_suite() {
 	# set up testing suite if it doesn't yet exist
 	if [ ! -d "$WP_TESTS_DIR" ]; then
 		mkdir -p "$WP_TESTS_DIR"
+		rm -rf /tmp/wordpress-develop
 		if ! git clone --quiet --depth=1 --branch "$GIT_REF" https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-develop; then
 			echo "Error: Failed to clone wordpress-develop at branch/tag $GIT_REF" >&2
 			exit 1


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #54 (issue #74).

The `git clone` in `install_test_suite()` would fail on re-runs if `/tmp/wordpress-develop` already existed from a previous execution. Adding `rm -rf /tmp/wordpress-develop` immediately before the clone ensures idempotent behaviour.

## Changes

* `bin/install-wp-tests.sh`: add `rm -rf /tmp/wordpress-develop` before `git clone` (line 120)

## Verification

* ShellCheck: zero violations
* Logic: the `rm -rf` is inside the `if [ ! -d "$WP_TESTS_DIR" ]` guard, so it only runs when the test suite is being freshly installed — consistent with the reviewer's suggestion

Closes #74