### PR TITLE
fix: validate type parameter against allow-list in showMessage (issue #76)

### DIFF
--- a/admin/js/update-source-selector.js
+++ b/admin/js/update-source-selector.js
@@ -147,17 +147,21 @@
     /**
 		 * Show a message in the modal
 		 *
-		 * @param {string} type Message type (success, error)
+		 * @param {string} type    Message type (success, error)
 		 * @param {string} message Message text
 		 */
     showMessage: function (type, message) {
       const $message = this.$modal.find( '.wpst-modal-message' );
 
-      // Set message as plain text to prevent XSS, then apply type class.
-      $message.text( message ).removeClass( 'success error' ).addClass( type ).show();
+      // Validate type against allow-list to prevent class injection vulnerabilities.
+      const allowedTypes = [ 'success', 'error' ];
+      const safeType = allowedTypes.includes( type ) ? type : 'error';
+
+      // Set message as plain text to prevent XSS, then apply validated type class.
+      $message.text( message ).removeClass( 'success error' ).addClass( safeType ).show();
 
       // Hide message after a delay for success messages.
-      if (type === 'success') {
+      if (safeType === 'success') {
         setTimeout(
           function () {
             $message.fadeOut( 300 );


### PR DESCRIPTION
## Summary

Addresses the medium-severity review finding from PR #47 (gemini-code-assist).

The `type` parameter in `showMessage()` was passed directly to `addClass()` without validation, creating a potential class injection vulnerability if the function's callers change in the future.

## Changes

- Added allow-list validation in `showMessage()` against `['success', 'error']`
- Any unexpected `type` value safely falls back to `'error'`
- Updated the `if (type === 'success')` check to use `safeType` for consistency
- Improved JSDoc alignment for `@param` tags

## Security

This is a defensive measure — the current callers only pass `'success'` or `'error'`, so there is no active exploit. The fix ensures the function remains safe if usage changes in the future.

Closes #76