### PR TITLE
t079: fix redundant existence check in cypress plugin activation test

### DIFF
--- a/cypress/e2e/playground-single-site.cy.js
+++ b/cypress/e2e/playground-single-site.cy.js
@@ -20,8 +20,9 @@ describe('WordPress Playground Single Site Tests', () => {
     cy.get('body', { timeout: 15000 }).then(($body) => {
       // Verify the starter template plugin exists and is activated.
       if ($body.find('tr[data-slug="wp-plugin-starter-template-for-ai-coding"]').length) {
-        cy.get('tr[data-slug="wp-plugin-starter-template-for-ai-coding"]').should('exist');
-        cy.get('tr[data-slug="wp-plugin-starter-template-for-ai-coding"] .deactivate a').should('exist');
+        cy.get('tr[data-slug="wp-plugin-starter-template-for-ai-coding"]').within(() => {
+          cy.get('.deactivate a').should('exist');
+        });
       } else {
         cy.log('Starter template plugin not found by slug, skipping check');
       }


### PR DESCRIPTION
## Summary

* Removes the redundant `.should('exist')` on line 23 — the `if` condition already confirms element presence via `.length`
* Refactors to use `cy.within()` to scope the `.deactivate a` assertion, eliminating selector repetition and improving readability
* Matches the suggestion from Gemini Code Assist review on PR #50

## Changes

`cypress/e2e/playground-single-site.cy.js` — lines 22-25 refactored from:
```js
cy.get('tr[data-slug="..."]').should('exist');
cy.get('tr[data-slug="..."] .deactivate a').should('exist');
```
to:
```js
cy.get('tr[data-slug="..."]').within(() => {
  cy.get('.deactivate a').should('exist');
});
```

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test specificity for plugin detection checks, enhancing reliability by scoping assertions within relevant component areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->