### PR TITLE
t077: fix: add lint:js to quality script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:php": "composer run-script test",
     "lint": "composer run-script lint",
     "fix": "composer run-script fix",
-    "quality": "npm run lint && npm run lint:css && npm run test:php"
+    "quality": "npm run lint && npm run lint:js && npm run lint:css && npm run test:php"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

* Adds `npm run lint:js` to the `quality` script in `package.json`, between `lint` (PHP) and `lint:css`
* Ensures JavaScript linting is part of the comprehensive quality gate alongside PHP and CSS checks
* Addresses Gemini code review feedback from PR #55 (medium severity)

## Change

\`\`\`diff
-    "quality": "npm run lint && npm run lint:css && npm run test:php"
+    "quality": "npm run lint && npm run lint:js && npm run lint:css && npm run test:php"
\`\`\`

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality checks by integrating additional JavaScript linting validation into the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->