### PR TITLE
t071: fix: address PR #65 review feedback on error-checking-feedback-loops.md

### DIFF
--- a/.agents/error-checking-feedback-loops.md
+++ b/.agents/error-checking-feedback-loops.md
@@ -77,7 +77,7 @@ uses: actions/upload-artifact@v4
 
 **Solution**: Use port 80 for multisite environments:
 
-```yaml
+```bash
 npx @wp-playground/cli server --blueprint playground/multisite-blueprint.json --port 80 --login &
 ```
 
@@ -142,7 +142,7 @@ npm run test:playground:multisite
 2. **Analyze Output for Errors**:
 
    ```bash
-   cat test-output.log | grep -i 'error\|fail\|exception'
+   grep -i 'error\|fail\|exception' test-output.log
    ```
 
 3. **Parse Structured Test Results** (if available):
@@ -221,7 +221,7 @@ npm run lint:css
 2. **Analyze Output for Errors**:
 
    ```bash
-   cat phpcs-output.log | grep -i 'ERROR\|WARNING'
+   grep -i 'ERROR\|WARNING' phpcs-output.log
    ```
 
 3. **Automatically Fix Issues** (when possible):


### PR DESCRIPTION
## Summary

Addresses the 3 findings from Gemini's review of PR #65 on `.agents/error-checking-feedback-loops.md`.

* Fix incorrect `yaml` language specifier on line 80 — the block contains a shell command, changed to `bash`
* Remove useless `cat` pipe on line 145 — `grep` reads files directly; `cat file | grep` is a UUOC anti-pattern
* Remove useless `cat` pipe on line 224 — same pattern, `grep` reads `phpcs-output.log` directly

Closes #71