### PR TITLE
quality-debt: change comma-dangle to always-multiline

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
     sourceType: 'module'
   },
   rules: {
-    'comma-dangle': ['error', 'never'],
+    'comma-dangle': ['error', 'always-multiline'],
     'no-console': 'warn',
     'no-unused-vars': 'warn'
   },

--- a/admin/js/admin-scripts.js
+++ b/admin/js/admin-scripts.js
@@ -78,7 +78,7 @@
           data: {
             action: 'wpst_save_settings',
             nonce: wpstData.nonce,
-            formData: formData
+            formData: formData,
           },
           success: function (response) {
             if (response.success) {
@@ -93,8 +93,8 @@
           complete: function () {
             // Re-enable submit button and remove loading state.
             $submitButton.prop( 'disabled', false ).removeClass( 'loading' );
-          }
-        }
+          },
+        },
       );
     },
 
@@ -123,19 +123,19 @@
             300,
             function () {
               $( this ).remove();
-            }
+            },
           );
         },
-        5000
+        5000,
       );
-    }
+    },
   };
 
   // Initialize when document is ready.
   $( document ).ready(
     function () {
       WPSTAdmin.init();
-    }
+    },
   );
 
 })( jQuery );

--- a/admin/js/update-source-selector.js
+++ b/admin/js/update-source-selector.js
@@ -48,7 +48,7 @@
           if ($( e.target ).hasClass( 'wpst-modal' )) {
             WPSTUpdateSourceSelector.closeModal();
           }
-        }
+        },
       );
 
       // Select source option.
@@ -116,7 +116,7 @@
           data: {
             action: 'wpst_set_update_source', // AJAX action hook.
             nonce: wpstModalData.nonce, // Security nonce.
-            source: this.selectedSource
+            source: this.selectedSource,
           },
           success: function (response) {
             if (response.success) {
@@ -127,7 +127,7 @@
                 function () {
                   WPSTUpdateSourceSelector.closeModal();
                 },
-                1500
+                1500,
               );
             } else {
               WPSTUpdateSourceSelector.showMessage( 'error', response.data.message );
@@ -139,8 +139,8 @@
           complete: function () {
             // Reset button state.
             $saveButton.prop( 'disabled', false ).text( wpstModalData.i18n.confirm );
-          }
-        }
+          },
+        },
       );
     },
 
@@ -162,17 +162,17 @@
           function () {
             $message.fadeOut( 300 );
           },
-          3000
+          3000,
         );
       }
-    }
+    },
   };
 
   // Initialize when document is ready.
   $( document ).ready(
     function () {
       WPSTUpdateSourceSelector.init();
-    }
+    },
   );
 
 })( jQuery );


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #66 (Gemini Code Assist suggestion at `.eslintrc.js:19`).

* Changes `'comma-dangle'` ESLint rule from `'never'` to `'always-multiline'`
* Updates `admin/js/admin-scripts.js` and `admin/js/update-source-selector.js` to comply with the new rule (15 trailing commas added on multiline structures)

## Rationale

`always-multiline` is the widely-adopted standard (Prettier default, Airbnb style guide). Benefits:
* **Cleaner git diffs** — adding a new last item doesn't require modifying the previous line
* **Easier reordering** — lines can be moved without introducing syntax errors

All JS files pass ESLint with zero violations after this change.

Closes #73