### PR TITLE
98: Address PR #81 review feedback in Playground-Testing.md

### DIFF
--- a/.wiki/Playground-Testing.md
+++ b/.wiki/Playground-Testing.md
@@ -102,7 +102,9 @@ In a WordPress multisite environment, there are two ways to activate plugins:
 1. **Network Activation**: Activates a plugin for all sites in the network
    * In the WordPress admin, go to Network Admin > Plugins
    * Click "Network Activate" under the plugin
-   * Or use WP-CLI: `wp plugin activate plugin-name --network` (for installed plugins), or `wp plugin install plugin-name --activate-network` (to install and activate)
+   * Or use WP-CLI:
+      * For plugins already installed: `wp plugin activate plugin-name --network`
+      * To install and activate in one step: `wp plugin install plugin-name --activate-network`
 
 2. **Per-Site Activation**: Activates a plugin for a specific site
    * In the WordPress admin, go to the specific site's admin area


### PR DESCRIPTION
## Summary
* Restructures the long WP-CLI network activation bullet in `.wiki/Playground-Testing.md` into a short parent bullet with two readable sub-bullets.
* Documents both reviewed command paths: activate an already installed plugin and install + network-activate in one command.

Closes #98