### PR TITLE
110: Fix PHPCS output grep pattern in error-checking guide

### DIFF
--- a/.agents/error-checking-feedback-loops.md
+++ b/.agents/error-checking-feedback-loops.md
@@ -221,7 +221,7 @@ npm run lint:css
 2. **Analyze Output for Errors**:
 
    ```bash
-   grep -E -i '\b(ERROR|WARNING)\b' phpcs-output.log
+   grep -E -i '\b(ERROR|WARNING)' phpcs-output.log
    ```
 
 3. **Automatically Fix Issues** (when possible):


### PR DESCRIPTION
## Summary
* Investigated PR #112 failure first and confirmed the failing check was `WordPress Playground Single Site Tests` due to a Cypress assertion in `playground-single-site.cy.js` (plugin activation), not this documentation regex change.
* Updated the PHPCS log parsing example to match both singular and plural tokens (`ERROR`/`WARNING` and `ERRORS`/`WARNINGS`) by removing the trailing word boundary.
* Kept the fix minimal and scoped to `.agents/error-checking-feedback-loops.md`.

## Validation
* Reviewed failed job logs from run `23318940109` (job `67825560370`) and captured the failure at `cypress/e2e/playground-single-site.cy.js:24`.
* Verified the updated regex matches plural PHPCS summary tokens with a local grep check.

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the PHPCS log parsing pattern documentation to simplify error and warning detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->