### PR TITLE
t109: streamline npm lint and quality scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
     "fix:php": "composer run-script phpcbf",
     "fix:php:simple": "composer run-script phpcbf:simple",
     "test:php": "composer run-script test",
-    "lint": "composer run-script lint",
+    "lint:php-all": "composer run-script lint",
+    "lint": "npm run lint:php-all && npm run lint:js && npm run lint:css",
     "fix": "composer run-script fix",
-    "quality": "npm run lint && npm run lint:js && npm run lint:css && npm run test:php"
+    "quality": "npm run lint && npm run test:php"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

* Renames `lint` to `lint:php-all` for clarity (PHP-only linting)
* Makes `lint` run all linters (PHP, JS, CSS) — more intuitive for developers
* Simplifies `quality` to avoid duplication (now just `lint` + `test:php`)

Addresses gemini review feedback from PR #103 (issue #109).

Closes #109