### PR TITLE
t120: fix: revert WP-CLI network activation to inline format for consistency

### DIFF
--- a/.wiki/Playground-Testing.md
+++ b/.wiki/Playground-Testing.md
@@ -102,9 +102,7 @@ In a WordPress multisite environment, there are two ways to activate plugins:
 1. **Network Activation**: Activates a plugin for all sites in the network
    * In the WordPress admin, go to Network Admin > Plugins
    * Click "Network Activate" under the plugin
-   * Or use WP-CLI:
-      * To activate an already installed plugin: `wp plugin activate plugin-name --network`
-      * To install and activate in one step: `wp plugin install plugin-name --activate-network`
+   * Or use WP-CLI: `wp plugin activate plugin-name --network`
 
 2. **Per-Site Activation**: Activates a plugin for a specific site
    * In the WordPress admin, go to the specific site's admin area


### PR DESCRIPTION
## Summary

* Reverts the WP-CLI network activation line in `.wiki/Playground-Testing.md` from a two-sub-bullet nested format back to a single inline `Or use WP-CLI: \`command\`` format.
* Eliminates the inconsistency between the **Network Activation** and **Per-Site Activation** sections — both now use identical phrasing structure.
* Addresses the medium-severity finding flagged by Gemini code review on PR #114 (unactioned at merge time).

## Change

**Before** (lines 105-107):
\`\`\`
   * Or use WP-CLI:
      * To activate an already installed plugin: \`wp plugin activate plugin-name --network\`
      * To install and activate in one step: \`wp plugin install plugin-name --activate-network\`
\`\`\`

**After** (line 105):
\`\`\`
   * Or use WP-CLI: \`wp plugin activate plugin-name --network\`
\`\`\`

This matches the Per-Site Activation section and the reviewer's explicit suggestion.

Closes #120