### PR TITLE
119: fix PHPCS severity regex in error-checking feedback loops doc

### DIFF
--- a/.agents/error-checking-feedback-loops.md
+++ b/.agents/error-checking-feedback-loops.md
@@ -221,7 +221,7 @@ npm run lint:css
 2. **Analyze Output for Errors**:
 
    ```bash
-   grep -E -i '\b(ERROR|WARNING)' phpcs-output.log
+   grep -E -i '\b(ERROR|WARNING)S?\b' phpcs-output.log || true
    ```
 
 3. **Automatically Fix Issues** (when possible):


### PR DESCRIPTION
## Summary
* Updates the PHPCS log grep example to `\\b(ERROR|WARNING)S?\\b` so it matches singular and plural severities without broad prefix matching.
* Addresses unactioned Gemini review feedback from PR #115 captured in issue #119.

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal error-detection workflow robustness to handle edge cases more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->