### PR TITLE
fix: move sync-wiki.yml secrets to env block (S7636)

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -50,4 +50,8 @@ jobs:
           git commit -m "Sync wiki from source repository"
 
           # Push changes
-          git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git
+          git push https://${WIKI_ACTOR}:${WIKI_TOKEN}@github.com/${WIKI_REPO}.wiki.git
+        env:
+          WIKI_ACTOR: ${{ github.actor }}
+          WIKI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WIKI_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Resolves the remaining SonarCloud S7636 hotspot in `sync-wiki.yml` by moving the `GITHUB_TOKEN` secret out of the `run` block URL and into an `env` block, then referencing it via environment variable.

## Changes

- `.github/workflows/sync-wiki.yml`: replace inline `${{ secrets.GITHUB_TOKEN }}` in git remote URL with `env: GH_TOKEN` + `$GH_TOKEN` reference

## Context

The `sonarcloud.yml` and `code-quality.yml` S7636 hotspots were resolved in prior merged commits. This PR addresses the last remaining hotspot, which should clear the SonarCloud quality gate (`new_security_hotspots_reviewed` 0% → 100%).

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal wiki synchronisation workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->