### PR TITLE
fix: move secrets to env blocks in CI workflows to resolve SonarCloud S7636 (#127)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -143,8 +143,10 @@ jobs:
 
       - name: Check if Codacy token is set
         id: check_codacy_token
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
-          if [ -z "${{ secrets.CODACY_PROJECT_TOKEN }}" ]; then
+          if [ -z "${CODACY_PROJECT_TOKEN}" ]; then
             echo "CODACY_PROJECT_TOKEN is not set, running Codacy without upload"
             echo "skip_upload=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -39,8 +39,10 @@ jobs:
 
       - name: Check if SonarCloud token is set
         id: check_token
+        env:
+          SONARCLOUD_GITHUB: ${{ secrets.SONARCLOUD_GITHUB }}
         run: |
-          if [ -z "${{ secrets.SONARCLOUD_GITHUB }}" ]; then
+          if [ -z "${SONARCLOUD_GITHUB}" ]; then
             echo "SONARCLOUD_GITHUB is not set, skipping SonarCloud analysis"
             echo "skip=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

Resolves the two remaining SonarCloud S7636 security hotspots by moving secrets out of \`run\` block expressions and into \`env\` blocks, then referencing them via environment variables.

## Changes

- \`.github/workflows/code-quality.yml\`: add \`env: CODACY_PROJECT_TOKEN\` block to the *Check if Codacy token is set* step; replace \`\${{ secrets.CODACY_PROJECT_TOKEN }}\` with \`\${CODACY_PROJECT_TOKEN}\` in the shell script
- \`.github/workflows/sonarcloud.yml\`: add \`env: SONARCLOUD_GITHUB\` block to the *Check if SonarCloud token is set* step; replace \`\${{ secrets.SONARCLOUD_GITHUB }}\` with \`\${SONARCLOUD_GITHUB}\` in the shell script

## Pattern

Follows the same approach used in PR #124 for \`sync-wiki.yml\`.

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows for code quality integration. Token validation in both Codacy and SonarCloud checks has been refactored to utilise environment variable injection instead of direct secret references. This change improves code quality processes and enhances the overall robustness and long-term reliability of the CI/CD pipeline token management mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->