### PR TITLE
t135: docs: restore --activate-network and add install+activate commands to multisite section

### DIFF
--- a/.wiki/Playground-Testing.md
+++ b/.wiki/Playground-Testing.md
@@ -102,12 +102,16 @@ In a WordPress multisite environment, there are two ways to activate plugins:
 1. **Network Activation**: Activates a plugin for all sites in the network
    * In the WordPress admin, go to Network Admin > Plugins
    * Click "Network Activate" under the plugin
-   * Or use WP-CLI: `wp plugin activate plugin-name --network`
+   * Or use WP-CLI:
+      * Activate an installed plugin: `wp plugin activate plugin-name --network`
+      * Install and activate a new plugin: `wp plugin install plugin-name --activate-network`
 
 2. **Per-Site Activation**: Activates a plugin for a specific site
    * In the WordPress admin, go to the specific site's admin area
    * Go to Plugins and activate the plugin for that site only
-   * Or use WP-CLI: `wp plugin activate plugin-name --url=site-url`
+   * Or use WP-CLI:
+      * Activate an installed plugin: `wp plugin activate plugin-name --url=site-url`
+      * Install and activate a new plugin: `wp plugin install plugin-name --activate --url=site-url`
 
 Our multisite blueprint uses network activation for both the Plugin Toggle and Kadence Blocks plugins.
 


### PR DESCRIPTION
## Summary

Addresses Gemini code review feedback from PR #122 that was tracked as quality-debt in issue #135.

* Restores the \`wp plugin install plugin-name --activate-network\` command that was removed from the Network Activation section during PR #122
* Expands both WP-CLI bullet points in the Network Activation section to distinguish between activating an already-installed plugin vs. installing and activating a new one
* Adds equivalent install+activate command (\`wp plugin install plugin-name --activate --url=site-url\`) to the Per-Site Activation section for consistency

## Changes

**File**: \`.wiki/Playground-Testing.md\` (lines 102–114)

Before:
\`\`\`
* Or use WP-CLI: \`wp plugin activate plugin-name --network\`
\`\`\`

After:
\`\`\`
* Or use WP-CLI:
   * Activate an installed plugin: \`wp plugin activate plugin-name --network\`
   * Install and activate a new plugin: \`wp plugin install plugin-name --activate-network\`
\`\`\`

The Per-Site Activation section receives the same treatment for parity.

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin activation instructions with expanded WP-CLI examples for multisite environments, clarifying procedures for both activating installed plugins and installing with activation across network and per-site scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->