### PR TITLE
GH#148: add AI tool discipline guidance to prevent recurring error patterns

### DIFF
--- a/.agents/ai-tool-best-practices.md
+++ b/.agents/ai-tool-best-practices.md
@@ -18,7 +18,9 @@ Implementing these practices reduces wasted tokens, failed edits, and broken pip
 
 **Failure pattern**: `edit:not_read_first` — 71 occurrences across 3 models.
 
-**Root cause**: AI assistants attempt to use the Edit or Write tool on a file without first reading it with the Read tool. The Edit tool requires knowing the exact current content to construct a valid `oldString`/`newString` replacement.
+**Root cause**: AI assistants attempt to use the Edit or Write tool on a file without first reading it with the
+Read tool. The Edit tool requires knowing the exact current content to construct a valid
+`oldString`/`newString` replacement.
 
 ### Rules
 
@@ -44,7 +46,8 @@ Edit: includes/core.php (no prior Read in this session)
 
 **Failure pattern**: `edit:edit_stale_read` — 32 occurrences across 3 models.
 
-**Root cause**: After an Edit or Write tool call, the in-memory content of the file is immediately stale. A second Edit based on the pre-edit content will fail because `oldString` no longer matches the file on disk.
+**Root cause**: After an Edit or Write tool call, the in-memory content of the file is immediately stale.
+A second Edit based on the pre-edit content will fail because `oldString` no longer matches the file on disk.
 
 ### Rules
 
@@ -73,7 +76,8 @@ Edit: admin/lib/admin.php       (second change — oldString is stale, will fail
 
 **Failure pattern**: `read:file_not_found` — 23 occurrences across 4 models.
 
-**Root cause**: AI assistants attempt to read files at paths that do not exist — usually due to assumed paths, renamed files, or path confusion in a multi-worktree workspace.
+**Root cause**: AI assistants attempt to read files at paths that do not exist — usually due to assumed paths,
+renamed files, or path confusion in a multi-worktree workspace.
 
 ### Rules
 
@@ -106,13 +110,15 @@ See [Known File Paths in This Repository](#known-file-paths-in-this-repository) 
 
 **Failure pattern**: `bash:other` — 66 occurrences across 3 models.
 
-**Root cause**: Bash tool calls fail for multiple reasons — wrong working directory, missing prerequisite tools, incorrect paths, unquoted strings with spaces, and commands that exit non-zero unexpectedly.
+**Root cause**: Bash tool calls fail for multiple reasons — wrong working directory, missing prerequisite tools,
+incorrect paths, unquoted strings with spaces, and commands that exit non-zero unexpectedly.
 
 ### Rules
 
 1. **Verify working directory** — use `pwd` if uncertain before running path-dependent commands.
 2. **Check prerequisites** — verify `composer`, `npm`, `php`, `wp-cli`, etc. are available before using them.
-3. **Use `|| true` for acceptable failures** — if a command failing is expected or acceptable in a pipeline, append `|| true`.
+3. **Use `|| true` for acceptable failures** — if a command failing is expected or acceptable in a pipeline,
+   append `|| true`.
 4. **Quote paths with spaces** — always double-quote paths that may contain spaces.
 5. **Check exit codes explicitly** — for critical commands, test `$?` or use `set -e` in scripts.
 

--- a/.agents/ai-tool-best-practices.md
+++ b/.agents/ai-tool-best-practices.md
@@ -1,0 +1,237 @@
+# AI Tool Best Practices
+
+This document addresses recurring AI tool failure patterns detected from real development sessions in this repository.
+
+These patterns were observed across multiple AI models (Claude, GPT-4, Gemini) and are tracked as contributor insights.
+
+Implementing these practices reduces wasted tokens, failed edits, and broken pipelines.
+
+## Table of Contents
+
+* [Read Before Edit](#read-before-edit)
+* [Re-Read After Edit](#re-read-after-edit)
+* [Verify File Paths Before Reading](#verify-file-paths-before-reading)
+* [Bash Command Hygiene](#bash-command-hygiene)
+* [Known File Paths in This Repository](#known-file-paths-in-this-repository)
+
+## Read Before Edit
+
+**Failure pattern**: `edit:not_read_first` — 71 occurrences across 3 models.
+
+**Root cause**: AI assistants attempt to use the Edit or Write tool on a file without first reading it with the Read tool. The Edit tool requires knowing the exact current content to construct a valid `oldString`/`newString` replacement.
+
+### Rules
+
+* ALWAYS use the Read tool on a file before using Edit or Write on it.
+* This applies even when you wrote the file yourself earlier in the session — something else may have modified it.
+* This applies even for single-line changes — you need the surrounding context lines.
+* If another tool (Bash, a script, a build step) has modified a file since you last read it, re-read before editing.
+
+### Correct pattern
+
+```
+Read: includes/core.php
+Edit: includes/core.php (oldString matches what Read returned)
+```
+
+### Incorrect pattern (causes edit:not_read_first)
+
+```
+Edit: includes/core.php (no prior Read in this session)
+```
+
+## Re-Read After Edit
+
+**Failure pattern**: `edit:edit_stale_read` — 32 occurrences across 3 models.
+
+**Root cause**: After an Edit or Write tool call, the in-memory content of the file is immediately stale. A second Edit based on the pre-edit content will fail because `oldString` no longer matches the file on disk.
+
+### Rules
+
+* After any Edit or Write to a file, re-read it before making a second edit.
+* The required sequence for multiple edits to the same file is: Read → Edit → Re-read → Edit → Re-read → Edit.
+* Never chain two Edit calls to the same file without a Read in between.
+
+### Correct pattern
+
+```
+Read: admin/lib/admin.php       (get current content)
+Edit: admin/lib/admin.php       (first change)
+Read: admin/lib/admin.php       (get updated content)
+Edit: admin/lib/admin.php       (second change)
+```
+
+### Incorrect pattern (causes edit:edit_stale_read)
+
+```
+Read: admin/lib/admin.php       (get current content)
+Edit: admin/lib/admin.php       (first change)
+Edit: admin/lib/admin.php       (second change — oldString is stale, will fail)
+```
+
+## Verify File Paths Before Reading
+
+**Failure pattern**: `read:file_not_found` — 23 occurrences across 4 models.
+
+**Root cause**: AI assistants attempt to read files at paths that do not exist — usually due to assumed paths, renamed files, or path confusion in a multi-worktree workspace.
+
+### Rules
+
+* Before reading a file, verify it exists using `git ls-files '<pattern>'`.
+* Use `git ls-files | grep <keyword>` when the exact path is uncertain.
+* Never assume a file exists based on what you expect the project structure to contain.
+* Paths in git worktrees differ from the canonical repo — the worktree root is a different directory.
+
+### Verification commands
+
+```bash
+# Check a specific file exists
+git ls-files 'includes/core.php'
+
+# Find files matching a keyword
+git ls-files | grep 'admin'
+
+# List all tracked PHP files
+git ls-files '*.php'
+
+# List all tracked files in a directory
+git ls-files 'includes/'
+```
+
+### Known tracked paths in this repository
+
+See [Known File Paths in This Repository](#known-file-paths-in-this-repository) below.
+
+## Bash Command Hygiene
+
+**Failure pattern**: `bash:other` — 66 occurrences across 3 models.
+
+**Root cause**: Bash tool calls fail for multiple reasons — wrong working directory, missing prerequisite tools, incorrect paths, unquoted strings with spaces, and commands that exit non-zero unexpectedly.
+
+### Rules
+
+1. **Verify working directory** — use `pwd` if uncertain before running path-dependent commands.
+2. **Check prerequisites** — verify `composer`, `npm`, `php`, `wp-cli`, etc. are available before using them.
+3. **Use `|| true` for acceptable failures** — if a command failing is expected or acceptable in a pipeline, append `|| true`.
+4. **Quote paths with spaces** — always double-quote paths that may contain spaces.
+5. **Check exit codes explicitly** — for critical commands, test `$?` or use `set -e` in scripts.
+
+### Common failure causes and fixes
+
+#### Wrong working directory
+
+```bash
+# Before a path-sensitive command, verify location
+pwd
+
+# Or use absolute paths
+composer run phpcs --working-dir="/path/to/repo"
+```
+
+#### Missing prerequisite
+
+```bash
+# Check tool exists before using it
+command -v composer || echo "composer not found"
+command -v npm || echo "npm not found"
+```
+
+#### Command that may fail in pipeline
+
+```bash
+# Acceptable failure — don't abort the pipeline
+npm run lint:js || true
+
+# Check exit code explicitly when the result matters
+composer run phpcs
+if [ $? -ne 0 ]; then
+    echo "PHPCS found violations"
+fi
+```
+
+#### Unquoted paths
+
+```bash
+# Correct — quoted
+git ls-files '*.php'
+
+# Incorrect — may be interpreted by shell
+git ls-files *.php
+```
+
+### Preferred commands for this repository
+
+```bash
+# PHP code quality
+composer run phpcs     # Check coding standards
+composer run phpcbf    # Auto-fix coding standards
+
+# JavaScript
+npm run lint:js        # ESLint check
+npm run lint:css       # Stylelint check
+
+# Tests
+composer run phpunit   # PHP unit tests
+npm run test:single    # Cypress single-site tests
+npm run test:multisite # Cypress multisite tests
+
+# Build
+bash build.sh          # Build plugin release zip
+```
+
+## Known File Paths in This Repository
+
+Use these paths directly. Verify with `git ls-files` if uncertain.
+
+### Core plugin files
+
+* `wp-plugin-starter-template.php` — Main plugin file with plugin headers
+* `includes/plugin.php` — Main plugin class that initializes all components
+* `includes/core.php` — Core functionality class
+* `includes/updater.php` — Update mechanism for multiple sources
+
+### Admin files
+
+* `admin/lib/admin.php` — Admin class for admin-specific functionality
+* `admin/lib/modal.php` — Modal class for update source selector
+* `admin/css/` — Admin stylesheets directory
+* `admin/js/` — Admin JavaScript files directory
+
+### Configuration and tooling
+
+* `composer.json` — PHP dependencies and scripts
+* `package.json` — Node.js dependencies and scripts
+* `phpcs.xml` — PHP CodeSniffer configuration
+* `phpcs-simple.xml` — Simplified PHPCS configuration
+* `phpstan.neon` — PHPStan static analysis configuration
+* `phpunit.xml` — PHPUnit test configuration
+* `.eslintrc.js` — ESLint JavaScript configuration
+* `.stylelintrc.json` — Stylelint CSS configuration
+
+### Documentation and AI guides
+
+* `AGENTS.md` — Primary AI assistant guide for this repository
+* `README.md` — Public-facing readme for GitHub
+* `readme.txt` — WordPress.org readme
+* `CHANGELOG.md` — Change log
+* `.agents/` — Detailed AI assistant documentation directory
+* `.wiki/` — Wiki documentation templates
+
+### Testing
+
+* `tests/` — PHP unit test files
+* `cypress/` — Cypress end-to-end test files
+* `playground/` — WordPress Playground blueprint files
+* `bin/` — Helper scripts for local development and testing
+
+### GitHub Actions
+
+* `.github/workflows/` — CI/CD workflow definitions
+
+## Summary: The Golden Rule
+
+**Read → Edit → Re-read → Edit. Always verify paths. Always check prerequisites.**
+
+Every edit failure in this repository has been traced to one of these four patterns.
+
+Following these rules eliminates the most common class of AI tool failures in this codebase.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,39 @@ This project uses several automated code quality tools to ensure high standards:
 
 Always run PHPCS and PHPCBF locally before committing code to ensure it meets the project's coding standards.
 
+## AI Tool Discipline
+
+Recurring tool failures detected from real sessions in this repository. Follow these rules to avoid them.
+
+For detailed guidance, see **@.agents/ai-tool-best-practices.md**.
+
+### Read Before Edit (critical — 71 `edit:not_read_first` failures)
+
+* ALWAYS use the Read tool on a file before using Edit or Write on it.
+* Never assume file content — always read first, even for small changes.
+* If you already read the file earlier in the session, re-read it if any other tool has modified it since.
+
+### Re-Read After Edit (32 `edit:edit_stale_read` failures)
+
+* After editing a file, always re-read it before making additional edits to the same file.
+* In-memory content becomes stale immediately after any modification.
+* Pattern: Read → Edit → Re-read → Edit (never Read → Edit → Edit).
+
+### Verify File Paths Before Reading (23 `read:file_not_found` failures)
+
+* Before reading a file, verify it exists: `git ls-files '<pattern>'` for tracked files.
+* Key tracked paths in this repo: `wp-plugin-starter-template.php`, `includes/`, `admin/`, `languages/`, `.agents/`.
+* If a path is uncertain, use `git ls-files | grep <keyword>` to find the correct path.
+* Never assume a file exists — verify first.
+
+### Bash Command Hygiene (66 `bash:other` failures)
+
+* Verify the working directory before running commands — use `pwd` if uncertain.
+* Check prerequisites exist before using them (e.g., `composer`, `npm`, `php`).
+* Use `|| true` when a command failure is acceptable in a pipeline.
+* For commands that may fail, check exit codes explicitly.
+* Common root causes: wrong working directory, missing tool, incorrect path, shell syntax error.
+
 ## Common Tasks
 
 For detailed instructions on releases, features, bugs, and testing, see **@.agents/release-process.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,8 @@ echo esc_html__('This is a translatable string', 'wp-plugin-starter-template');
 ## Git Workflow
 
 * Always keep the canonical repository on `main` — all development work goes on feature branches
-* Prefer Git worktrees for feature development (`git worktree add ../repo-feature-name feature/feature-name`); this avoids switching branches in the main directory
+* Prefer Git worktrees for feature development (`git worktree add ../repo-feature-name feature/feature-name`);
+  this avoids switching branches in the main directory
 * Use descriptive branch names (e.g., `feature/add-settings-page`)
 * Make atomic commits with clear messages
 * Create pull requests (GitHub) or merge requests (GitLab/Gitea/Forgejo) for review — the workflow is platform-agnostic


### PR DESCRIPTION
## Summary

Adds explicit AI tool discipline guidance to `AGENTS.md` and a new `.agents/ai-tool-best-practices.md` file, addressing 4 recurring error patterns detected from real development sessions in this repository.

## What Changed

**`AGENTS.md`** — new `## AI Tool Discipline` section with actionable rules for each error pattern, placed before `## Common Tasks` so AI assistants encounter it early in their context window.

**`.agents/ai-tool-best-practices.md`** — new detailed guide covering:

* Read-before-edit requirement and correct sequence
* Re-read-after-edit requirement and anti-pattern examples
* File path verification with `git ls-files` before reading
* Bash command hygiene (working directory, prerequisites, `|| true`, quoting)
* Known file paths in this repository for quick reference

## Why

Issue #148 detected these recurring failures across 3-4 AI models:

* `edit:not_read_first` — 71 occurrences: edit attempted without prior read
* `bash:other` — 66 occurrences: various bash tool failures
* `edit:edit_stale_read` — 32 occurrences: edit attempted with stale in-memory content
* `read:file_not_found` — 23 occurrences: read attempted on non-existent path

Without explicit guidance, these patterns recur across every new AI session. The fix is documentation that appears in context before the first edit.

## Verification

No code changes — documentation only. No linting required.

Resolves #148

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 3m and 11,395 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AI tool best practices guide documenting usage patterns, recurring failure prevention, and repository-specific file references.
  * Updated contributor documentation with procedural guidelines for file reading/editing sequences and command execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->