### PR TITLE
GH#147: strengthen worktree guidance from 'prefer' to 'always, no exceptions'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,8 +186,7 @@ echo esc_html__('This is a translatable string', 'wp-plugin-starter-template');
 ## Git Workflow
 
 * Always keep the canonical repository on `main` — all development work goes on feature branches
-* Prefer Git worktrees for feature development (`git worktree add ../repo-feature-name feature/feature-name`);
-  this avoids switching branches in the main directory
+* Always use Git worktrees for feature development (`git worktree add ../repo-feature-name feature/feature-name`) — no exceptions; this avoids switching branches in the main directory
 * Use descriptive branch names (e.g., `feature/add-settings-page`)
 * Make atomic commits with clear messages
 * Create pull requests (GitHub) or merge requests (GitLab/Gitea/Forgejo) for review — the workflow is platform-agnostic


### PR DESCRIPTION
## Summary

Triage of contributor-insight issue #147 (8 instruction candidates from contributor sessions).

**Candidates evaluated:** 8 total

* 6/8 are aidevops framework-specific (pulse, MCP, OpenCode model picker, signature system, Opus 4.7 context benchmarks) — not applicable to this WordPress plugin repo's AGENTS.md
* 1/8 (GitLab/Gitea platform support): already covered at AGENTS.md line 193 — no change needed
* 1/8 (worktrees from main, no exceptions): **actionable** — current wording used "Prefer" which was weaker than the stated developer intent

## Change

Strengthened Git Workflow worktree guidance:

* Before: `Prefer Git worktrees for feature development`
* After: `Always use Git worktrees for feature development ... — no exceptions`

This aligns the documented guidance with the developer's expressed preference ("we always work on worktrees from main, no exceptions").

## Verification

Documentation-only change. No code modified.

Resolves #147

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 6,155 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal documentation updates only with no changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->