### PR TITLE
GH#151: fix git worktree command — add -b flag and main base branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ echo esc_html__('This is a translatable string', 'wp-plugin-starter-template');
 ## Git Workflow
 
 * Always keep the canonical repository on `main` — all development work goes on feature branches
-* Always use Git worktrees for feature development (`git worktree add ../repo-feature-name feature/feature-name`) — no exceptions; this avoids switching branches in the main directory
+* Always use Git worktrees for feature development (`git worktree add -b feature/feature-name ../repo-feature-name main`) — no exceptions; this avoids switching branches in the main directory
 * Use descriptive branch names (e.g., `feature/add-settings-page`)
 * Make atomic commits with clear messages
 * Create pull requests (GitHub) or merge requests (GitLab/Gitea/Forgejo) for review — the workflow is platform-agnostic


### PR DESCRIPTION
## Summary

Fix the `git worktree add` command in AGENTS.md to use the `-b` flag and specify `main` as the base branch, ensuring the command works correctly for new feature development.

## What changed

**EDIT: `AGENTS.md:189`**

Before:
```
git worktree add ../repo-feature-name feature/feature-name
```

After:
```
git worktree add -b feature/feature-name ../repo-feature-name main
```

The original command would fail if the feature branch did not already exist. Adding `-b` creates the branch, and specifying `main` ensures it branches from the correct base.

## Verification

The change is doc-only (no code). Verified by reading the updated line.

Resolves #151
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 1m and 2,428 tokens on this as a headless worker.