### PR TITLE
GH#153: clarify worktree command for new branches and use project-specific path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ echo esc_html__('This is a translatable string', 'wp-plugin-starter-template');
 ## Git Workflow
 
 * Always keep the canonical repository on `main` — all development work goes on feature branches
-* Always use Git worktrees for feature development (`git worktree add -b feature/feature-name ../repo-feature-name main`) — no exceptions; this avoids switching branches in the main directory
+* Always use Git worktrees for feature development (e.g., for a new branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`) — no exceptions; this avoids switching branches in the main directory
 * Use descriptive branch names (e.g., `feature/add-settings-page`)
 * Make atomic commits with clear messages
 * Create pull requests (GitHub) or merge requests (GitLab/Gitea/Forgejo) for review — the workflow is platform-agnostic


### PR DESCRIPTION
## Summary

Updated `AGENTS.md` Git Workflow section (line 189) to address PR #152 review feedback from Gemini:

1. Added "e.g., for a new branch:" prefix to clarify the `git worktree add -b` command is specifically for creating new branches (since `-b` fails if the branch already exists)
2. Replaced generic `../repo-feature-name` path with project-specific `../wp-plugin-starter-template-feature-name` for consistency with the project context

Resolves #153

## Testing

- Verified the edit reads correctly at line 189
- Documentation-only change, no functional impact

<!-- MERGE_SUMMARY -->
## Merge Summary
**What**: Clarified worktree command in AGENTS.md to note it's for new branches and use project-specific path placeholder.
**Why**: PR #152 Gemini review flagged that `-b` fails on existing branches and the example path should match the project name.
**Testing**: Visual verification of line 189 content. Docs-only change.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 2m and 2,825 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated Git workflow instructions with explicit naming conventions for feature branch worktrees, providing clearer guidance for developers setting up local development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->