### PR TITLE
GH#155: docs: add existing branch worktree command to Git Workflow section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ echo esc_html__('This is a translatable string', 'wp-plugin-starter-template');
 ## Git Workflow
 
 * Always keep the canonical repository on `main` — all development work goes on feature branches
-* Always use Git worktrees for feature development (e.g., for a new branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`) — no exceptions; this avoids switching branches in the main directory
+* Always use Git worktrees for feature development (e.g., for a new branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`; for an existing branch: `git worktree add ../wp-plugin-starter-template-feature-name feature/feature-name`) — no exceptions; this avoids switching branches in the main directory
 * Use descriptive branch names (e.g., `feature/add-settings-page`)
 * Make atomic commits with clear messages
 * Create pull requests (GitHub) or merge requests (GitLab/Gitea/Forgejo) for review — the workflow is platform-agnostic


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #154 (gemini-code-assist finding).

The Git Workflow section previously only documented the command for creating a **new** worktree branch, leaving the policy incomplete for the common scenario of returning to an **existing** branch.

## Change

Updated `AGENTS.md:189` to include both commands:
- New branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`
- Existing branch: `git worktree add ../wp-plugin-starter-template-feature-name feature/feature-name`

## Verification

The change is documentation-only. Verified the updated line reads correctly at `AGENTS.md:189`.

Resolves #155

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 2m and 3,993 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Git Workflow documentation with expanded Git worktrees usage examples, now illustrating how to create new feature branches from main and add worktrees to existing branches whilst maintaining best practices for branch management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->