### PR TITLE
GH#158: docs: split worktree examples into sub-bullets for readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,9 @@ echo esc_html__('This is a translatable string', 'wp-plugin-starter-template');
 ## Git Workflow
 
 * Always keep the canonical repository on `main` — all development work goes on feature branches
-* Always use Git worktrees for feature development (e.g., for a new branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`; for an existing branch: `git worktree add ../wp-plugin-starter-template-feature-name feature/feature-name`) — no exceptions; this avoids switching branches in the main directory
+* Always use Git worktrees for feature development — no exceptions; this avoids switching branches in the main directory:
+    * New branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`
+    * Existing branch: `git worktree add ../wp-plugin-starter-template-feature-name feature/feature-name`
 * Use descriptive branch names (e.g., `feature/add-settings-page`)
 * Make atomic commits with clear messages
 * Create pull requests (GitHub) or merge requests (GitLab/Gitea/Forgejo) for review — the workflow is platform-agnostic


### PR DESCRIPTION
## Summary

Splits the dense Git worktree instruction in `AGENTS.md` into sub-bullets for improved readability, as suggested by Gemini reviewer in PR #156.

## Changes

- **EDIT: `AGENTS.md:189`** — Reformatted the single long worktree instruction into a parent bullet with two indented sub-bullets:
  - New branch example
  - Existing branch example

## Verification

The resulting structure matches the suggestion exactly:
```
* Always use Git worktrees for feature development — no exceptions; this avoids switching branches in the main directory:
    * New branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`
    * Existing branch: `git worktree add ../wp-plugin-starter-template-feature-name feature/feature-name`
```

Resolves #158

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 1m and 3,275 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Git workflow documentation to clarify mandatory worktree requirements with improved formatting and separated command examples for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->