### PR TITLE
GH#160: Resolve Dependabot security alerts in dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2025-2026 WPALLSTARS
+
+# Dependabot configuration for automated dependency updates.
+# Schedules weekly checks for npm, composer, and GitHub Actions dependencies.
+# Security updates are grouped by minor/patch to reduce PR noise.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "php"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 10

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5759c820289b50690d6ce01f85ada5ee",
+    "content-hash": "2b909d58b573666bb381f0b4e3d8768a",
     "packages": [],
     "packages-dev": [
         {
@@ -598,16 +598,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.2",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -650,9 +650,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-10-21T19:32:17+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -1722,16 +1722,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.29",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -1753,7 +1753,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -1805,7 +1805,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -1829,7 +1829,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:29:11+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "psr/container",
@@ -2098,16 +2098,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -2160,7 +2160,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -2180,7 +2180,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3328,16 +3328,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -3387,7 +3387,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3407,7 +3407,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -462,6 +462,19 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1062,32 +1075,85 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@php-wasm/fs-journal": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.0.22.tgz",
-      "integrity": "sha512-0aRtl2G/yejbyAC6guesznFKsg2EN3QEAjjKOJZ+QJogVT3szys0td8tNcQ0fcHYoSJj9lS8yZ+84EjpWN4LzQ==",
+    "node_modules/@php-wasm/cli-util": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.21.tgz",
+      "integrity": "sha512-LQ/c+vtkLmmPtPoQ/6Nh22lERNzaQmMeE38UGzCvf6PhIj0IoASvA4HthIdrdLegMbp0iG4abfkzTfGkhQzHvg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
-        "express": "4.21.2",
+        "@php-wasm/util": "3.1.21",
+        "fast-xml-parser": "^5.5.1",
+        "jsonc-parser": "3.3.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/logger": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.21.tgz",
+      "integrity": "sha512-ykuQcn2k7anSKOrkC46WHTKiC3/oh08RbHGiAMPnZymzG3fCHJbc1/LdH8CmkZdyNJqHt6nhAaYf7Ll8glG5Dg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.21.tgz",
+      "integrity": "sha512-KAUbGH8ITHabpSxYlR3zV+dq3ml1QN1TGcdLXMdLrbonKUO36g0TPZr1/ddtf05QBgFiyx7JHIiB1ljvFqMLSQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/cli-util": "3.1.21",
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node-5-2": "3.1.21",
+        "@php-wasm/node-7-4": "3.1.21",
+        "@php-wasm/node-8-0": "3.1.21",
+        "@php-wasm/node-8-1": "3.1.21",
+        "@php-wasm/node-8-2": "3.1.21",
+        "@php-wasm/node-8-3": "3.1.21",
+        "@php-wasm/node-8-4": "3.1.21",
+        "@php-wasm/node-8-5": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
         "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/fs-journal/node_modules/ini": {
+    "node_modules/@php-wasm/node-5-2": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.21.tgz",
+      "integrity": "sha512-l06b+B+NVyUxP9/mfyUSkjbNt4/BFy/YUzfob0teFByFUbcps1dKNqE5B042IERf+Laz9kuoS8ly9+VbFqVDkA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-5-2/node_modules/ini": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
       "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
@@ -1097,57 +1163,193 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@php-wasm/logger": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.0.22.tgz",
-      "integrity": "sha512-AlomcaUmpBSSrkFNET5MOKVsqdTTID05nXWNKqgViRQaeepksIFukZYo1xm3XOAP/OhdKZ7IyblyfMSuStOVAg==",
+    "node_modules/@php-wasm/node-7-4": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.21.tgz",
+      "integrity": "sha512-n9CRZRl0QI6/Q46W2HldKpAlVqZbyjvyvK2Ph2p6kktpCCAJsJ9JqTUjGSh3iuHgT+8DYBlxw1kMineqLLwNgQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "3.0.22"
-      },
-      "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
-      }
-    },
-    "node_modules/@php-wasm/node": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.0.22.tgz",
-      "integrity": "sha512-OlbCIGFB4ACHlha0C+MVYT47RKqulMUu35C1j6VdUAkYcen+QpzbXJGH4wMTBAkcw+q/jWUqllgGjDsoWDjj/w==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node-polyfills": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
-        "@wp-playground/common": "3.0.22",
-        "express": "4.21.2",
+        "@php-wasm/universal": "3.1.21",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
-        "yargs": "17.7.2"
+        "ws": "8.18.0"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/node-polyfills": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.0.22.tgz",
-      "integrity": "sha512-Q5T8n6wEQGTUn1eP61FmQdQO4rxavR3IeW95Fj++QIkMs9ZfllmuWepbu02rWP6unk6Do7IZoNprqRz7Lyc9og==",
+    "node_modules/@php-wasm/node-7-4/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@php-wasm/node-8-0": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.21.tgz",
+      "integrity": "sha512-dF2G6fcEYDm1yfoR5PWqasImYWPmRf76SLWx3WSXbhrunwDLVDgSuj4d17BmlA5fK/DkUnHHFf4QxwQWqyrUqQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-0/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@php-wasm/node-8-1": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.21.tgz",
+      "integrity": "sha512-SYIBDst+g8CNYw8t4VZ9yiv6GdmKX3NOIAqQ1tFo3fmAOc6VgK9qpQcmCmpwmMIxrHg6BcijvV7qTgJmZ93MmQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-1/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@php-wasm/node-8-2": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.21.tgz",
+      "integrity": "sha512-pB/fFHVtFiRTuXHCVa6ev6vSXwUq7075CLaGye04CpKi+CgsMhX54Qb9UOJNg5kbOp3fxSPnpYTB9ZwfUYnruw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-2/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@php-wasm/node-8-3": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.21.tgz",
+      "integrity": "sha512-RKFVIaul0rgf2aal6QoulOPTF9JUbNd7d0p+p5FJrntUhbjdaW9rICOOmgbwUl1hXiq2HDmRaGX1ZpxCsbVXGQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-3/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@php-wasm/node-8-4": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.21.tgz",
+      "integrity": "sha512-ZI5Pd0T2KqL8XfAX3eCULPbeLM0YmkbPbwye5siS6NXPW1lO0oHyJ91eKfRFLttCdzrkWndW/x1uimKVJFqEqg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-4/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@php-wasm/node-8-5": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.21.tgz",
+      "integrity": "sha512-i01P6zf+EWnVBRudPfokP4Z4Q1N4dy12mjDRfioANv0YqRCcyFgCc6ngJKN4/e0Ew+qhbkjTBkoRpscm4+RewA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-5/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@php-wasm/node/node_modules/ini": {
@@ -1161,71 +1363,56 @@
       }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.0.22.tgz",
-      "integrity": "sha512-jkiP4hPDtqN4bkSI7X2OSjhtSQdxLqznofI32vLASGQu3SaaZO6iaqf0JBtnbJQL4n1TgQrqIe2PA/cNkRUKYA==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.21.tgz",
+      "integrity": "sha512-fF7HCeXXptWGNSr8d3Tlyjelax8AnvpyZGWUtwNYI27428oIXhGEwsphlAHMfPfc5YEFz9BQEhHoTU7z/SRlbg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node-polyfills": "3.0.22"
+        "@php-wasm/logger": "3.1.21"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.0.22.tgz",
-      "integrity": "sha512-BG2mdeQ3Xf9C1gZ6wpnS8gjGTbxnUG/EE0CCG2d0Vb3pDhjTMBbJIJx8y0Mly1OoQxv1xMjb68aXS+A0yEunZw==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.21.tgz",
+      "integrity": "sha512-BTECa1MsKv/RJxOaP+M/4MjilZpnYvYKTB2Kng8hrmYBA6LjuGnP1UY8yiCCUHsxnFxfRm6pW+c8Duy+ZTpVpw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.0.22.tgz",
-      "integrity": "sha512-uM/spZwgbuY9ZcTiCBl0ZvG0DwCahVn73DHQY7JtiN6uTRe4IsjTQtoOCZPjFFhTFvnf+ZSSCHw4sE9+oTpezg==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.21.tgz",
+      "integrity": "sha512-VB+M15HL0krTo2yK9xswWzxby+K+gAHMtYhg7NhL7fhFIv/dKRkCv/dYAazwGNXP4/T7RxlPpchRpeFi+7ndjA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "3.0.22",
-        "@php-wasm/util": "3.0.22"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "@php-wasm/util": "3.1.21"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.0.22.tgz",
-      "integrity": "sha512-fh0MovmoWsz2F01KWZ2a14Ou6G+yKMduLnLIiFIcUfFqoWFvu8WW+yM29CfcDqx56/9aCRWltueckdcNZ9871g==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.21.tgz",
+      "integrity": "sha512-JuaLJvGE2jCmLY+GYkz2yFpxjTrb4QzqXodKo3IDYe+hO9nhmPhBg5oootftPfMMKlYdyIfOT1jv3AUy6ihb+Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node-polyfills": "3.0.22",
-        "@php-wasm/progress": "3.0.22",
-        "@php-wasm/stream-compression": "3.0.22",
-        "@php-wasm/util": "3.0.22",
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/progress": "3.1.21",
+        "@php-wasm/stream-compression": "3.1.21",
+        "@php-wasm/util": "3.1.21",
         "ini": "4.1.2"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/universal/node_modules/ini": {
@@ -1239,62 +1426,32 @@
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.0.22.tgz",
-      "integrity": "sha512-RX6yqg56xHx4/uxHXXFhrWtyj1+lVrlJL95Y3D/gkX+XcX2lrgAgRJSTrINhM9OZq7Amxz0DxDLQVglJi2Imfw==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.21.tgz",
+      "integrity": "sha512-D2JYnqKJv5n7qArvczEPa2aX/vlVbdOBZ+MJJKUHAgzqun8wRT7kJXfW0XQ2C9EYvW9mFQ4gm7sYbpiEHUB8+g==",
       "dev": true,
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
-      }
-    },
-    "node_modules/@php-wasm/web": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.0.22.tgz",
-      "integrity": "sha512-BgfduJYdE0JIBTPjogDJiWqLdxM/JmWtAlKbmVlGtIeWGA9PJU9DMyhrzSeQkcx8zTN/wG3qDLgIrojJ2PII6A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/fs-journal": "3.0.22",
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
-        "@php-wasm/web-service-worker": "3.0.22",
-        "express": "4.21.2",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
-        "yargs": "17.7.2"
-      },
-      "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.0.22.tgz",
-      "integrity": "sha512-OijEAI6/Rf6G9Do4E87OqGpCFW56uyU2Gl007IHJjV8cEOQLXVPfFpi0+VE4Tbr9Ba4NjB1GEFIUJJIHX08/3g==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.21.tgz",
+      "integrity": "sha512-ZLxbCfw+t3VKkZtVj7kUE3hNJ3PVFU47pakUcpvfDq9+yAOQggx3IPLH5/YokWHu3pm+G9eCIRuHcMZuLa5J/w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.0.22"
+        "@php-wasm/scopes": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/web/node_modules/ini": {
+    "node_modules/@php-wasm/web-service-worker/node_modules/ini": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
       "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
@@ -1305,20 +1462,23 @@
       }
     },
     "node_modules/@php-wasm/xdebug-bridge": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.0.22.tgz",
-      "integrity": "sha512-nYM3ryfYSxYjJYKkT65UmBoV/aS+I72lOL9k35TMLB+NCLSC3Z5srPZ8GoVxq9nJDVFs8I4a77SwUthA/q58PA==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.21.tgz",
+      "integrity": "sha512-BHeMn6EwFfV6hszwqPm0VNoFtdSoVr/5TTzZ9OpUZckPdxz2jfGEmix4tNrqW/+OtUUSi0oZmbPUZ8F8zv6YxA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@wp-playground/common": "3.0.22",
-        "express": "4.21.2",
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
         "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "xml2js": "0.6.2",
         "yargs": "17.7.2"
       },
@@ -1326,11 +1486,8 @@
         "xdebug-bridge": "xdebug-bridge.js"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/xdebug-bridge/node_modules/ini": {
@@ -1341,6 +1498,23 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -1508,31 +1682,34 @@
       }
     },
     "node_modules/@wp-playground/blueprints": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.0.22.tgz",
-      "integrity": "sha512-Rx1b70k7RTeT7gkqVbQvHDgjXoqJHXPkyKh2XUnLg9CDhe/FNvbhYD/mFZMGI7JLqMlf2C5cCxdMUFcHSQuC8A==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.21.tgz",
+      "integrity": "sha512-O9ry40j8y/zDXnDwza/qz3kKNHC1mXYKgqX7MD53jMTgkZZCzcQe3tUGf+k8LJV1WBWkaimI8cdUtU4r1KF6xA==",
       "dev": true,
       "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node": "3.0.22",
-        "@php-wasm/node-polyfills": "3.0.22",
-        "@php-wasm/progress": "3.0.22",
-        "@php-wasm/stream-compression": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
-        "@php-wasm/web": "3.0.22",
-        "@wp-playground/common": "3.0.22",
-        "@wp-playground/storage": "3.0.22",
-        "@wp-playground/wordpress": "3.0.22",
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/progress": "3.1.21",
+        "@php-wasm/scopes": "3.1.21",
+        "@php-wasm/stream-compression": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@php-wasm/web-service-worker": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "@wp-playground/storage": "3.1.21",
+        "@wp-playground/wordpress": "3.1.21",
         "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
         "clean-git-ref": "2.0.1",
         "crc-32": "1.2.2",
         "diff3": "0.0.4",
-        "express": "4.21.2",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
         "ignore": "5.3.2",
         "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
         "minimisted": "2.0.1",
         "octokit": "3.1.2",
         "pako": "1.0.10",
@@ -1541,15 +1718,12 @@
         "sha.js": "2.4.12",
         "simple-get": "4.0.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@wp-playground/blueprints/node_modules/ini": {
@@ -1576,30 +1750,33 @@
       }
     },
     "node_modules/@wp-playground/cli": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.0.22.tgz",
-      "integrity": "sha512-sWCtiX21Dh+8m8BRsSeumW2BcPpc36PkMDvMAJnLh7y8FmPPnqOY0rzOWBAmm19dHjCx8DiLuUZ7oo+est6g8A==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.21.tgz",
+      "integrity": "sha512-FQjxHRF/fwL9Lg6MRTnVFeDzKdOy9e2uDxUiXx5o9uZEAQdMqMsD8U+aY8j7BrwlUedkZu2oTap2c0CP/Xqouw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node": "3.0.22",
-        "@php-wasm/progress": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
-        "@php-wasm/xdebug-bridge": "3.0.22",
-        "@wp-playground/blueprints": "3.0.22",
-        "@wp-playground/common": "3.0.22",
-        "@wp-playground/storage": "3.0.22",
-        "@wp-playground/wordpress": "3.0.22",
+        "@php-wasm/cli-util": "3.1.21",
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/progress": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@php-wasm/xdebug-bridge": "3.1.21",
+        "@wp-playground/blueprints": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "@wp-playground/storage": "3.1.21",
+        "@wp-playground/tools": "3.1.21",
+        "@wp-playground/wordpress": "3.1.21",
         "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
         "clean-git-ref": "2.0.1",
         "crc-32": "1.2.2",
         "diff3": "0.0.4",
-        "express": "4.21.2",
-        "fast-xml-parser": "5.3.0",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
         "fs-extra": "11.1.1",
         "ignore": "5.3.2",
         "ini": "4.1.2",
@@ -1608,21 +1785,17 @@
         "octokit": "3.1.2",
         "pako": "1.0.10",
         "pify": "2.3.0",
-        "ps-man": "1.1.8",
         "readable-stream": "3.6.2",
         "sha.js": "2.4.12",
         "simple-get": "4.0.1",
         "tmp-promise": "3.0.3",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "xml2js": "0.6.2",
         "yargs": "17.7.2"
       },
       "bin": {
         "wp-playground-cli": "wp-playground.js"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@wp-playground/cli/node_modules/fs-extra": {
@@ -1677,22 +1850,19 @@
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.0.22.tgz",
-      "integrity": "sha512-iH/lmymV1d3xX6o64AxEnv/CKLpfo8bkifxTkIBSk9wKmbxaGUsjGO2uTP5W9abpKOkdnlY6Nm8ESh1OGW7DtQ==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.21.tgz",
+      "integrity": "sha512-NEM8gwpksjiGohLuikvKo2+qOKE7LlatUEQBe3MqzMOpJtItxnCBBFTo21mH9/0ZzuHCn7udFdVwWoF5ZjbBMQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
         "ini": "4.1.2"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@wp-playground/common/node_modules/ini": {
@@ -1706,22 +1876,20 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.0.22.tgz",
-      "integrity": "sha512-zjsxvfVNphvbGOzc1Q0EkaOxs9TokdPlncBk8ye5vzmNhvl0Glyfu3pErfHs/L/f0ftRw4eBk1VUgPCS8BxNDA==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.21.tgz",
+      "integrity": "sha512-6Is8Pjx+WpWlVPE/7Oxks19sK4wiaeFbFnGNcw1ICT6i0ssbZIULWq1kwkshHM2czop/PKM2SyxjhiSMd++EMw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
-        "@php-wasm/web": "3.0.22",
+        "@php-wasm/stream-compression": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
         "crc-32": "^1.2.0",
         "diff3": "0.0.3",
-        "express": "4.21.2",
         "ignore": "^5.1.4",
         "ini": "4.1.2",
         "minimisted": "^2.0.0",
@@ -1730,13 +1898,7 @@
         "pify": "^4.0.1",
         "readable-stream": "^3.4.0",
         "sha.js": "^2.4.9",
-        "simple-get": "^4.0.1",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
-        "yargs": "17.7.2"
-      },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+        "simple-get": "^4.0.1"
       }
     },
     "node_modules/@wp-playground/storage/node_modules/diff3": {
@@ -1781,30 +1943,91 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@wp-playground/wordpress": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.0.22.tgz",
-      "integrity": "sha512-FbQruz+dBA/sWq+Xf3SaTl3O7uWI4NYPovTzFnf/f1TPswjyYWGg8cGcb3xpGYr8pENOiPTkV2jKWX/V9WX/nw==",
+    "node_modules/@wp-playground/tools": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.21.tgz",
+      "integrity": "sha512-rmGRMojgajgyhXfJco3NxPRN7qgfbSBO8vydPxu/odYP5qtD2lcC9IJXBSKWRUmI+CaJmVw49yltCxojTk0J0w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.0.22",
-        "@php-wasm/node": "3.0.22",
-        "@php-wasm/universal": "3.0.22",
-        "@php-wasm/util": "3.0.22",
-        "@wp-playground/common": "3.0.22",
-        "express": "4.21.2",
+        "@wp-playground/blueprints": "3.1.21",
+        "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
+        "async-lock": "1.4.1",
+        "clean-git-ref": "2.0.1",
+        "crc-32": "1.2.2",
+        "diff3": "0.0.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ignore": "5.3.2",
         "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "minimisted": "2.0.1",
+        "octokit": "3.1.2",
+        "pako": "1.0.10",
+        "pify": "2.3.0",
+        "readable-stream": "3.6.2",
+        "sha.js": "2.4.12",
+        "simple-get": "4.0.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.3",
+        "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
-        "node": ">=20.18.3",
-        "npm": ">=10.1.0"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wp-playground/tools/node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@wp-playground/tools/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       },
-      "optionalDependencies": {
-        "fs-ext": "2.1.1"
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@wp-playground/wordpress": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.21.tgz",
+      "integrity": "sha512-rEms03kG4DB9kKlK+9sOeO3TI8PvMhubRyXIhs/n061IqcEacCJvgr1Krwdb9IOViEaSusGkD6d/ao6IjqPxHA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/@wp-playground/wordpress/node_modules/ini": {
@@ -1881,15 +2104,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2149,24 +2373,24 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -2190,22 +2414,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -2214,9 +2422,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2720,9 +2928,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2730,9 +2938,9 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3445,9 +3653,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3634,40 +3842,40 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+      "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -3697,22 +3905,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3733,19 +3925,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/extract-zip": {
@@ -3841,10 +4020,27 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.0.tgz",
-      "integrity": "sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==",
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "dev": true,
       "funding": [
         {
@@ -3854,7 +4050,26 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3933,18 +4148,18 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.2",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -4034,15 +4249,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -4069,15 +4285,15 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs-ext": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fs-ext/-/fs-ext-2.1.1.tgz",
-      "integrity": "sha512-/TrISPOFhCkbgIRWK9lzscRzwPCu0PqtCcvMc9jsHKBgZGoqA0VzhspVht5Zu8lxaXjIYIBWILHpRotYkCCcQA==",
+    "node_modules/fs-ext-extra-prebuilt": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
+      "integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
       "dev": true,
       "hasInstallScript": true,
-      "optional": true,
+      "license": "MIT",
       "dependencies": {
-        "nan": "^2.21.0"
+        "nan": "^2.24.0"
       },
       "engines": {
         "node": ">= 8.0.0"
@@ -4516,20 +4732,24 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-signature": {
@@ -4904,9 +5124,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5037,13 +5257,13 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -5167,9 +5387,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5494,9 +5714,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5553,12 +5773,11 @@
       "license": "ISC"
     },
     "node_modules/nan": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.1.tgz",
-      "integrity": "sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5677,19 +5896,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/npm-run-all2/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/npm-run-all2/node_modules/pidtree": {
@@ -5944,16 +6150,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -6077,6 +6273,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6098,9 +6310,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6136,13 +6348,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -6169,9 +6381,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -6313,13 +6525,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ps-man": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ps-man/-/ps-man-1.1.8.tgz",
-      "integrity": "sha512-ZKDPZwHLYVWIk/Q75N7jCFbuQyokSg2+3WBlt8l35S/uBvxoc+LiRUbb3RUt83pwW82dzwiCpoQIHd9PAxUzHg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -6361,9 +6566,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6421,16 +6626,16 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -6667,11 +6872,14 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -6687,25 +6895,25 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -6728,27 +6936,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -6965,15 +7163,17 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
-      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.5"
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
       },
       "funding": {
         "type": "github",
@@ -7049,9 +7249,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7127,9 +7327,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "dev": true,
       "funding": [
         {
@@ -7448,9 +7648,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7706,13 +7906,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -7864,9 +8068,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -71,5 +71,26 @@
     "npm-run-all2": "^8.0.4",
     "stylelint": "^16.0.0",
     "stylelint-config-standard": "^36.0.0"
+  },
+  "overrides": {
+    "lodash": "^4.18.0",
+    "qs": "^6.14.2",
+    "tmp": "^0.2.4",
+    "simple-git": "^3.32.3",
+    "form-data": "^4.0.4",
+    "fast-xml-parser": "^5.7.0",
+    "minimatch": "^3.1.4",
+    "jws": "^3.2.3",
+    "js-yaml": "^3.14.2",
+    "picomatch": "^4.0.4",
+    "brace-expansion": "^1.1.13",
+    "postcss": "^8.5.10",
+    "express": "^4.22.0",
+    "path-to-regexp": "^0.1.13",
+    "uuid": "^14.0.0",
+    "ajv": "^8.18.0",
+    "eslint": {
+      "ajv": "^6.14.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "path-to-regexp": "^0.1.13",
     "uuid": "^14.0.0",
     "ajv": "^8.18.0",
+    "@eslint/eslintrc": {
+      "ajv": "^6.14.0"
+    },
     "eslint": {
       "ajv": "^6.14.0"
     }


### PR DESCRIPTION
## Summary

Resolves all 21+ open Dependabot security alerts (critical, high, medium, low) in dev-only dependencies. Plugin runtime is unaffected — all changes are in build/test tooling manifests.

Resolves #160

## Changes

### `package.json` — npm overrides block
Forces minimum-safe versions for 16 vulnerable transitive dependencies:

| Package | Minimum | Fixes |
|---|---|---|
| `lodash` | `^4.18.0` | Prototype pollution (high) |
| `simple-git` | `^3.32.3` | RCE option-parsing bypass (critical) |
| `form-data` | `^4.0.4` | Unsafe boundary RNG (critical) |
| `fast-xml-parser` | `^5.7.0` | DoS / entity expansion (critical) |
| `jws` | `^3.2.3` | Improperly verifies HMAC (high) |
| `minimatch` | `^3.1.4` | ReDoS via wildcards (high) |
| `qs` | `^6.14.2` | DoS via arrayLimit bypass (moderate) |
| `js-yaml` | `^3.14.2` | Prototype pollution in merge (moderate) |
| `picomatch` | `^4.0.4` | ReDoS advisories (moderate) |
| `brace-expansion` | `^1.1.13` | ReDoS vulnerability (moderate) |
| `postcss` | `^8.5.10` | XSS via unescaped style tag (moderate) |
| `express` | `^4.22.0` | path-to-regexp ReDoS (high) |
| `path-to-regexp` | `^0.1.13` | ReDoS multiple route params (high) |
| `uuid` | `^14.0.0` | Missing buffer bounds check (moderate) |
| `tmp` | `^0.2.4` | Arbitrary tmp file write (low) |
| `ajv` | `^8.18.0` (top-level) / `^6.14.0` (eslint-nested) | ReDoS via `$data` option (moderate) |

### `.npmrc`
Adds `legacy-peer-deps=true` — standardises the flag already used in all CI workflows.

### `package-lock.json`
Regenerated after overrides applied. `npm audit` reports 0 vulnerabilities.

### `composer.lock`
Updated via `composer update phpunit/phpunit --with-all-dependencies`. phpunit/phpunit bumped to 9.6.34. `composer audit` reports 0 advisories.

### `.github/dependabot.yml`
New file. Schedules weekly Dependabot scans for npm, Composer, and GitHub Actions. Minor/patch updates grouped to reduce PR noise.

## Verification

- `npm audit --audit-level=low` reports `found 0 vulnerabilities`
- `composer audit` reports `No security vulnerability advisories found.`
- `npm run lint:js` passes with 0 errors (eslint wired correctly)
- Repository `automated-security-fixes` confirmed enabled: `{"enabled":true,"paused":false}`

Note: pre-existing CSS lint error in `admin/css/admin-styles.css:127` (`media-feature-range-notation`) is unrelated to this PR.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 24m and 43,796 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Configured automated weekly dependency checks and updates
* Enabled npm legacy peer dependency resolution to improve package compatibility
* Added dependency version overrides to ensure consistent dependency resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->