### PR TITLE
GH#182: Use consistent example branch name in worktree commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,8 +187,8 @@ echo esc_html__('This is a translatable string', 'wp-plugin-starter-template');
 
 * Always keep the canonical repository on `main` — all development work goes on feature branches
 * Always use Git worktrees for feature development — no exceptions; this avoids switching branches in the main directory:
-    * New branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`
-    * Existing branch: `git worktree add ../wp-plugin-starter-template-feature-name feature/feature-name`
+    * New branch: `git worktree add -b feature/add-settings-page ../wp-plugin-starter-template-add-settings-page main`
+    * Existing branch: `git worktree add ../wp-plugin-starter-template-add-settings-page feature/add-settings-page`
 * Use descriptive branch names (e.g., `feature/add-settings-page`)
 * Make atomic commits with clear messages
 * Create pull requests (GitHub) or merge requests (GitLab/Gitea/Forgejo) for review — the workflow is platform-agnostic


### PR DESCRIPTION
## Summary

Use a consistent, concrete example branch name in the Git Workflow worktree commands.

## Changes

Updated `AGENTS.md` lines 190-191 to replace the generic `feature/feature-name` placeholder with the concrete `feature/add-settings-page` example that is already referenced in the following bullet point.

**Before:**
```
* New branch: `git worktree add -b feature/feature-name ../wp-plugin-starter-template-feature-name main`
* Existing branch: `git worktree add ../wp-plugin-starter-template-feature-name feature/feature-name`
```

**After:**
```
* New branch: `git worktree add -b feature/add-settings-page ../wp-plugin-starter-template-add-settings-page main`
* Existing branch: `git worktree add ../wp-plugin-starter-template-add-settings-page feature/add-settings-page`
```

## Testing

Documentation-only change. No functional code modified.

Resolves #182

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 4m and 4,494 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Git Workflow examples with concrete worktree setup commands for improved clarity and easier implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->