### PR TITLE
GH#175: chore: update ramsey composer install action

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,7 +49,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@83af392bf5f031813d25e6fe4cd626cdba9a2df6 # v2.2.0
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
 
       - name: Install WordPress test suite
         run: |


### PR DESCRIPTION
## Summary

Updated the pinned ramsey/composer-install GitHub Action in the PHPUnit workflow from v2.2.0 to v4.0.0.

## Files Changed

.github/workflows/phpunit.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; actionlint .github/workflows/phpunit.yml

Resolves #175


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 37,650 tokens on this as a headless worker.