### PR TITLE
GH#176: bump CodeQL upload SARIF action

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload SARIF results file
         if: steps.check_codacy_token.outputs.skip_upload != 'true'
-        uses: github/codeql-action/upload-sarif@603b797f8b14b413fe025cd935a91c16c4782713 # v3
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: results.sarif
         continue-on-error: true


### PR DESCRIPTION
## Summary

Updated the pinned github/codeql-action/upload-sarif action in the Code Quality workflow from v3 to v4.35.2.

## Files Changed

.github/workflows/code-quality.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified the workflow diff updates only .github/workflows/code-quality.yml to the v4.35.2 pinned commit.

Resolves #176


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 119,792 tokens on this as a headless worker.