### PR TITLE
GH#174: bump setup-node to 6.4.0

### DIFF
--- a/.github/workflows/playground-tests-fix.yml
+++ b/.github/workflows/playground-tests-fix.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/playground-tests.yml
+++ b/.github/workflows/playground-tests.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -68,7 +68,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
         cache: 'npm'
@@ -166,7 +166,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/wordpress-tests.yml
+++ b/.github/workflows/wordpress-tests.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
## Summary

Updated pinned actions/setup-node references in WordPress Playground and WordPress test workflows from v4 to v6.4.0.

## Files Changed

.github/workflows/playground-tests-fix.yml,.github/workflows/playground-tests.yml,.github/workflows/wordpress-tests.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check

Resolves #174


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 55,030 tokens on this as a headless worker.