### PR TITLE
GH#172: bump upload-artifact action

### DIFF
--- a/.github/workflows/playground-tests-fix.yml
+++ b/.github/workflows/playground-tests-fix.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Upload Cypress artifacts
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cypress-playground-results
         path: |

--- a/.github/workflows/playground-tests.yml
+++ b/.github/workflows/playground-tests.yml
@@ -143,7 +143,7 @@ jobs:
 
     - name: Upload Cypress artifacts
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cypress-single-site-results
         path: |
@@ -242,7 +242,7 @@ jobs:
 
     - name: Upload Cypress artifacts
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cypress-multisite-results
         path: |

--- a/.github/workflows/wordpress-tests.yml
+++ b/.github/workflows/wordpress-tests.yml
@@ -125,7 +125,7 @@ jobs:
 
     - name: Upload Cypress artifacts
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cypress-results
         path: |


### PR DESCRIPTION
## Summary
* Updated pinned actions/upload-artifact usages in workflow artifact upload steps from v4.6.2 to v7.0.1.
* Matches the Dependabot-proposed digest and version comment across the three affected workflows.

## Testing
* `actionlint .github/workflows/playground-tests-fix.yml .github/workflows/playground-tests.yml .github/workflows/wordpress-tests.yml` (reports pre-existing `if: false` warnings in `.github/workflows/playground-tests.yml`; no new syntax issue from this update).

For #172

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6m and 55,080 tokens on this as a headless worker.
