### PR TITLE
GH#171: bump SonarQube scan action

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: steps.check_token.outputs.skip != 'true'
-        uses: SonarSource/sonarqube-scan-action@9598b8a83feef37de07f549027fab50ecffe6a6e # master
+        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_GITHUB }}


### PR DESCRIPTION
## Summary

Updated the pinned SonarSource/sonarqube-scan-action commit used by the SonarCloud workflow to c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2.

## Files Changed

.github/workflows/sonarcloud.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check

Resolves #171


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 72,849 tokens on this as a headless worker.