### PR TITLE
GH#164: chore(deps-dev): bump simple-git override to 3.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lodash": "^4.18.0",
     "qs": "^6.14.2",
     "tmp": "^0.2.4",
-    "simple-git": "^3.32.3",
+    "simple-git": "^3.36.0",
     "form-data": "^4.0.4",
     "fast-xml-parser": "^5.7.0",
     "minimatch": "^3.1.4",


### PR DESCRIPTION
## Summary

Updated the npm overrides entry for simple-git to ^3.36.0 so the resolved transitive dependency matches the Dependabot target version.

## Files Changed

package.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm install --package-lock-only; npm run lint:js; npm audit --audit-level=moderate; npm explain simple-git

Resolves #164


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 57,048 tokens on this as a headless worker.