### PR TITLE
GH#161: require lodash 4.18.1 override

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "stylelint-config-standard": "^40.0.0"
   },
   "overrides": {
-    "lodash": "^4.18.0",
+    "lodash": "^4.18.1",
     "qs": "^6.14.2",
     "tmp": "^0.2.4",
     "simple-git": "^3.32.3",


### PR DESCRIPTION
## Summary
* Tightens the existing lodash npm override from `^4.18.0` to `^4.18.1` so the package manager resolves the patched release requested by Dependabot.
* Keeps the lockfile unchanged because `package-lock.json` already resolves `node_modules/lodash` to `4.18.1` on the current base.

## Testing
* `npm install`
* `npm explain lodash`
* `npm audit --audit-level=moderate`

Refs #161

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 61,608 tokens on this as a headless worker.