### PR TITLE
GH#198: bump WordPress Playground CLI and fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@wordpress/env": "^11.4.0",
         "@wp-playground/blueprints": "^3.0.22",
-        "@wp-playground/cli": "^3.0.22",
+        "@wp-playground/cli": "^3.1.21",
         "@wp-playground/client": "^3.1.21",
         "cypress": "^13.17.0",
         "eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@wordpress/env": "^11.4.0",
     "@wp-playground/blueprints": "^3.0.22",
-    "@wp-playground/cli": "^3.0.22",
+    "@wp-playground/cli": "^3.1.21",
     "@wp-playground/client": "^3.1.21",
     "cypress": "^13.17.0",
     "eslint": "^8.57.0",
@@ -78,7 +78,7 @@
     "tmp": "^0.2.4",
     "simple-git": "^3.36.0",
     "form-data": "^4.0.4",
-    "fast-xml-parser": "^5.7.0",
+    "fast-xml-parser": "^5.7.2",
     "minimatch": "^3.1.4",
     "jws": "^3.2.3",
     "js-yaml": "^3.14.2",


### PR DESCRIPTION
## Summary
* Updates `@wp-playground/cli` to `^3.1.21` while keeping `@wp-playground/client` at `^3.1.21`.
* Aligns the `fast-xml-parser` root override to `^5.7.2`.
* Preserves the lockfile resolutions for `@wp-playground/cli` `3.1.21` and `fast-xml-parser` `5.7.2`.

## Testing
* `npm install --package-lock-only`
* `npm run lint:js`
* `npm run lint:css`
* `npm run lint:php:simple` — fails on existing PHPCS spacing/naming violations in PHP files unrelated to this dependency-only change.

Resolves #198

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 65,228 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest compatible versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->