### PR TITLE
GH#213: optimize Cypress admin session validation

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,13 +27,18 @@ Cypress.Commands.add('loginAsAdmin', () => {
         cy.get('#wp-submit').should('be.visible').click();
       }
 
-      cy.visit('/wp-admin/', { timeout: 60000, failOnStatusCode: false });
-      cy.get('#wpbody-content', { timeout: 60000 }).should('exist');
+      cy.get('#wpbody-content', { timeout: 30000 }).should('exist');
     });
   }, {
     validate() {
-      cy.visit('/wp-admin/', { timeout: 60000, failOnStatusCode: false });
-      cy.get('#wpbody-content', { timeout: 60000 }).should('exist');
+      cy.request({
+        url: '/wp-admin/',
+        followRedirect: false,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.redirectedToUrl || '').not.to.include('wp-login.php');
+      });
     },
   });
 


### PR DESCRIPTION
## Summary
* Removed the redundant `/wp-admin/` visit after submitting the Cypress admin login form.
* Changed `cy.session` validation to use `cy.request()` with redirects disabled so cached session checks avoid full page loads.

## Testing
* `npm run lint:js`

Resolves #213

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) automated worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced automated administrative login verification testing for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->