### PR TITLE
Fix Cypress ESLint flat config path resolution

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,6 @@ const cypressGlobals = {
   assert: 'readonly',
   chai: 'readonly',
   cy: 'readonly',
-  expect: 'readonly',
 };
 
 const cypressRecommendedRules = cypress.configs.recommended.rules;
@@ -26,7 +25,7 @@ module.exports = [
   js.configs.recommended,
   {
     files: ['**/*.js'],
-    ignores: ['cypress/eslint.config.js'],
+    ignores: ['eslint.config.js'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
@@ -43,7 +42,6 @@ module.exports = [
   },
   {
     files: ['cypress/**/*.js'],
-    ignores: ['cypress/eslint.config.js'],
     languageOptions: {
       globals: {
         ...globals.browser,
@@ -63,7 +61,7 @@ module.exports = [
     },
   },
   {
-    files: ['cypress.config.js', 'cypress.config.cjs', 'cypress/eslint.config.js'],
+    files: ['cypress.config.js', 'cypress.config.cjs', 'eslint.config.js'],
     languageOptions: {
       sourceType: 'commonjs',
       globals: {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:phpunit": "composer test",
     "test:phpunit:multisite": "WP_MULTISITE=1 composer test",
     "build": "./build.sh",
-    "lint:js": "eslint --config cypress/eslint.config.js cypress/ cypress.config.js",
+    "lint:js": "eslint cypress/ cypress.config.js eslint.config.js",
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input",
     "lint:php": "composer run-script phpcs",
     "lint:php:simple": "composer run-script phpcs:simple",


### PR DESCRIPTION
## Summary
* Moved the Cypress ESLint flat config to the repository root so `files` and `ignores` patterns resolve from the project root.
* Updated `lint:js` to use the root flat config and include the root Cypress config file.

## Testing
* `npm ci --ignore-scripts`
* `npm run lint:js`

Resolves #215

<!-- MERGE_SUMMARY
summary: Moved the ESLint flat config to the repository root so Cypress and root config file patterns resolve correctly.
testing: npm ci --ignore-scripts; npm run lint:js
-->

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) automated worker
