### PR TITLE
Fix legacy admin mobile media query compatibility

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,7 @@
     "alpha-value-notation": "percentage",
     "color-function-notation": "modern",
     "font-weight-notation": "numeric",
-    "media-feature-range-notation": "context"
+    "media-feature-range-notation": "prefix"
   },
   "ignoreFiles": [
     "vendor/**",

--- a/admin/css/admin-styles.css
+++ b/admin/css/admin-styles.css
@@ -124,7 +124,7 @@
 }
 
 /* 782px is the WordPress mobile admin breakpoint. */
-@media screen and (width <= 782px) {
+@media screen and (max-width: 782px) {
     .wpst-form-table th {
         width: 100%;
         display: block;


### PR DESCRIPTION
## Summary
* Replaces the admin mobile breakpoint media query with `max-width` notation for Safari/iOS 15 compatibility.
* Updates Stylelint to require prefix media feature notation so future CSS follows the compatible pattern.

## Testing
* `npm run lint:css`

Resolves #201

<!-- MERGE_SUMMARY
Issue: #201
Summary: Replaced unsupported media query range syntax in `admin/css/admin-styles.css` and aligned `.stylelintrc.json` with prefix media query notation.
Testing: npm run lint:css
-->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) automated worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CSS code quality linting rules to enforce standardised media query notation across the codebase, improving consistency and standards compliance.
  * Revised media query syntax in administrative stylesheets to align with updated formatting guidelines, ensuring consistent styling patterns and better maintainability throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->