### PR TITLE
GH#222: fix: clarify legacy admin media query compatibility

### DIFF
--- a/admin/css/admin-styles.css
+++ b/admin/css/admin-styles.css
@@ -123,7 +123,7 @@
     text-align: right;
 }
 
-/* 782px is the WordPress mobile admin breakpoint. */
+/* Use max-width for Safari/iOS 15 compatibility at the WordPress mobile admin breakpoint. */
 @media screen and (max-width: 782px) {
     .wpst-form-table th {
         width: 100%;


### PR DESCRIPTION
## Summary

Confirmed the recovered CSS lint fix is present and documented the legacy Safari/iOS compatibility reason beside the admin mobile breakpoint.

## Files Changed

admin/css/admin-styles.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run lint:css

Resolves #222


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 64,063 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified compatibility notes for mobile admin interface across browsers and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->