### PR TITLE
GH#225: chore(deps): bump SonarQube scan action

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: steps.check_token.outputs.skip != 'true'
-        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # master
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_GITHUB }}


### PR DESCRIPTION
## Summary

Updated the pinned SonarSource/sonarqube-scan-action revision in .github/workflows/sonarcloud.yml from the v7.2.1 commit to the v8.0.0 commit.

## Files Changed

.github/workflows/sonarcloud.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; actionlint .github/workflows/sonarcloud.yml

Resolves #225


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 57,443 tokens on this as a headless worker.