### PR TITLE
GH#223: chore: bump WordPress Playground packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,13 +1576,13 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/cli-util": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.25.tgz",
-      "integrity": "sha512-U7hwd73amrSj1OX1LbvM7BJFr000n78OS6gVjilxD8t1HKL+BlGdFiIhX5hahsrxvaRNRDJTEuaN+lSd0SDpqg==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.26.tgz",
+      "integrity": "sha512-ROnL0vAb/hUth/nm+iKctlzIVKGMkXodW3G0Vnv5HCwA1Nyhj7hiCmn/9eR+lGRFcJfDc7akjVm6CmyA1lGcsw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.25",
+        "@php-wasm/util": "3.1.26",
         "fast-xml-parser": "^5.5.1",
         "jsonc-parser": "3.3.1"
       },
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.25.tgz",
-      "integrity": "sha512-+GVX8uzqAPOb2QE6oaHrLuH/842+g5NXa0kdzYNYOjwbuqzNcccUJBvZl3A7wEju0IjUR3tXck9YLiyeVqWN1A==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.26.tgz",
+      "integrity": "sha512-zMswdzK4SMakSJGoKLITGLGmmo4DfX7Q6qri+1QjEJsFf0RWAlBj7uu9oB+SJpF5b8FBBB53N6n/hRaA8DPYJw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1603,25 +1603,26 @@
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.25.tgz",
-      "integrity": "sha512-Bf6FBPiWq0ffRQ8Xw+7cG7bhCh3einftcJDAbLYLZidq0JVmHlyA6sRbux1wz5JtuMmdUQCo/AIsWyTTNBIhNQ==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.26.tgz",
+      "integrity": "sha512-Q7AKyt9Y+9XaUxJCvG4TGwQThYY2D+9FxjyCRLH8us9f0fbr/ZQA8cUCU2YM2CTlWLdJrT01Z/dnxEqOCdC6Ww==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.25",
-        "@php-wasm/logger": "3.1.25",
-        "@php-wasm/node-5-2": "3.1.25",
-        "@php-wasm/node-7-4": "3.1.25",
-        "@php-wasm/node-8-0": "3.1.25",
-        "@php-wasm/node-8-1": "3.1.25",
-        "@php-wasm/node-8-2": "3.1.25",
-        "@php-wasm/node-8-3": "3.1.25",
-        "@php-wasm/node-8-4": "3.1.25",
-        "@php-wasm/node-8-5": "3.1.25",
-        "@php-wasm/universal": "3.1.25",
-        "@php-wasm/util": "3.1.25",
-        "@wp-playground/common": "3.1.25",
+        "@php-wasm/cli-util": "3.1.26",
+        "@php-wasm/logger": "3.1.26",
+        "@php-wasm/node-5-2": "3.1.26",
+        "@php-wasm/node-7-4": "3.1.26",
+        "@php-wasm/node-8-0": "3.1.26",
+        "@php-wasm/node-8-1": "3.1.26",
+        "@php-wasm/node-8-2": "3.1.26",
+        "@php-wasm/node-8-3": "3.1.26",
+        "@php-wasm/node-8-4": "3.1.26",
+        "@php-wasm/node-8-5": "3.1.26",
+        "@php-wasm/universal": "3.1.26",
+        "@php-wasm/util": "3.1.26",
+        "@wp-playground/common": "3.1.26",
+        "ajv": "8.12.0",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
@@ -1637,13 +1638,14 @@
       }
     },
     "node_modules/@php-wasm/node-5-2": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.25.tgz",
-      "integrity": "sha512-vvCXWaGY1TfIvAXXq76yEw8VbofpITqtaEcUkibYEp2oZVJORR0nKveHVVpOkQPjoRfOVGvs/EAA0UpzPnMg+w==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.26.tgz",
+      "integrity": "sha512-Q+njtzwY7NrvT2N0JmNRV0JMBVG3L6SomkQFBZy7BSk6qPqsK889LhVmSvoElXP3vXfB6oqO9g8ALX3CKez9zw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1654,13 +1656,14 @@
       }
     },
     "node_modules/@php-wasm/node-7-4": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.25.tgz",
-      "integrity": "sha512-yJFVTOobad92e8l2wOI8IXxhOF7Rxuo79AKJgKBrnDYP6CcXrTgVXmWux252Dt8P3ekGs4xYqf8YfIRkEoy9wA==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.26.tgz",
+      "integrity": "sha512-VLiLnpWHCN4eQnnoTk7h0u1qCWJUV/8J7TaEqDtfR1OKR+L1L1W2bPzUNm5L4u5D14a8yrMdM362LNiaxer4mg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1671,13 +1674,14 @@
       }
     },
     "node_modules/@php-wasm/node-8-0": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.25.tgz",
-      "integrity": "sha512-hCRX0QS6vQehPskGFU8lk8JisFmQnAYaiVlDsKLgENXeUlE6Ze5Sb2lz62T0XCSf737c2K9ispVpO0nj9Qitww==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.26.tgz",
+      "integrity": "sha512-Ssl/X9Y1KvRowT9cmdb+yh6Fc+k8fZk9wiKqC2eImflK1Gjweg56YQPb/z7Gag1vWPYdck0TmC8WblPA+tIv2A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1688,13 +1692,14 @@
       }
     },
     "node_modules/@php-wasm/node-8-1": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.25.tgz",
-      "integrity": "sha512-q1yKeAfNYD/EfnQv4FVElNqxFEeatxGXx6b7ZvkZSRBCCHFY7EAU75iMu6t7XOreJG+2pVMss3hlgVnGQ+kq9Q==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.26.tgz",
+      "integrity": "sha512-FCe1PhNrRq8lRH3klam6JXmD9YKxBIgcsf+CGOXzrPW/MYiZhyACK0em1FlDyfFbc2w26whhu0TqRacuJSZUjA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1705,13 +1710,14 @@
       }
     },
     "node_modules/@php-wasm/node-8-2": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.25.tgz",
-      "integrity": "sha512-+0VgAgkIwshbMxUHWHS94gR9jSzA7C6uY7bvMgFLlD5btf7mtyXDR2LTiDx70ZwqVllRBeMakvH2Tt0puoXRpg==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.26.tgz",
+      "integrity": "sha512-HndHQtelVjPMVXf7NuNVwPcCm4DTWArXBFP3qK7eZ/ooG/N9inALfL5uSYnRFiWAYW+bZ+6l8/a8j/+kq6BYfA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1722,13 +1728,14 @@
       }
     },
     "node_modules/@php-wasm/node-8-3": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.25.tgz",
-      "integrity": "sha512-2IXixarMRb20fRFHU23A9GmitxLR/NFW1TC6LG5pIsWEjWo35of2ejchoSuGecdc0tbbY3jte/c+/+NaUdyFtw==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.26.tgz",
+      "integrity": "sha512-CyKnXJa47Y8CvNqBgr7m9m4gqoRvFrO2rgvRns6icEigZObU+qkYwjKUUH6LmDRbQU5mzhUpbhLcSe15+edy3Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1739,13 +1746,14 @@
       }
     },
     "node_modules/@php-wasm/node-8-4": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.25.tgz",
-      "integrity": "sha512-cGNOGU7AgWqtNoktCoqIfDKzk0eDKDObJ1UADj4iW3F4K3KegivB6OPcmOL3nqABJIzSnzGS+B4Ozc3BB7W6Gw==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.26.tgz",
+      "integrity": "sha512-Bp4SoG2bFGDD4MOmmCg7r2xOHmceo/zoJj0P+8Cgll8Na+NVTnrNdWC4cvFh9ZaFVh/Lx8+3FaPPfRknG7iudQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1756,13 +1764,14 @@
       }
     },
     "node_modules/@php-wasm/node-8-5": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.25.tgz",
-      "integrity": "sha512-BeeP9bsrO4SCiIqhacrxTdqcyxl0eonxVxPdbXSFOk5UVUNGFdNHCIMzUuO7zShL8auwKWpoPga7SYJy6pPxmg==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.26.tgz",
+      "integrity": "sha512-rbp9UTiBrVhcec9yZ+axWArFf/L/KBB4rUTHP0d1QYwFxeOfGv9UCowMt5eHcdsB8J66zgtc9iWk8GacGPqlGA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0"
@@ -1773,13 +1782,13 @@
       }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.25.tgz",
-      "integrity": "sha512-p6S7xRdpzPLRwdbKW57sIRp3HfPE50l8lFy5QRf+HZrOtFKGZ436aTukXVH6EPqdT+BOyyQkoEQnf0aL7Ru5/Q==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.26.tgz",
+      "integrity": "sha512-UTgXFK0/Y3ybCkG3SuuU1o4jD1SyhBVqGHcF40xrmHAyEvvHX4affIhqFeAga5ajWDwZFg5aDaapN+2q+0P0Mg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.25"
+        "@php-wasm/logger": "3.1.26"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1787,9 +1796,9 @@
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.25.tgz",
-      "integrity": "sha512-D84MigxrNfkHBNLa8uLt7EDXSEqv38TldSejmYZeZ/U10pMtXOfUz+4GOcsTZbZWue/+L+ks3HTge977ayduJg==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.26.tgz",
+      "integrity": "sha512-c5sRt36anv5WEChVlyWb3jPTj/TZE5dlOOBXw6zGVe4ZJdfun0APQee9W4yL6kpoLf3iGQL9JVl2z3Sd0CNYbA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1798,26 +1807,27 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.25.tgz",
-      "integrity": "sha512-SBFsHfSC6G3Dv1c/GhxRolSErHgaaRBFK8qfjol1wasyXkzsNmHYxjbcO4ohf72DH9UGNW9GrLjVe7DSJs8VGA==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.26.tgz",
+      "integrity": "sha512-eWqRZXtVrcXcrkakJoWAO2VXRq+JJ+CRphT95Qn99StqZdU6VhlgsYraBwrhAJrtSCRXUMIk33x7CwqKPU9Qew==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.25"
+        "@php-wasm/util": "3.1.26"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.25.tgz",
-      "integrity": "sha512-1ajxavT+WpvZZNyO0ifxM9DaBapIhFCkwdMsVK7N034z7woISjLa187chtLXIulHPPNJ1xLF8XER7YAXEVVk8w==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.26.tgz",
+      "integrity": "sha512-ZtA8P/XNmDpmCIbK4Pqo2nWICVrD6C12fcx42zuAh2E2NMEeXLtZnOUIEEBBI8ZcoV1t7LIlScVuOXV/0+iOiw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.25",
-        "@php-wasm/progress": "3.1.25",
-        "@php-wasm/stream-compression": "3.1.25",
-        "@php-wasm/util": "3.1.25",
+        "@php-wasm/logger": "3.1.26",
+        "@php-wasm/progress": "3.1.26",
+        "@php-wasm/stream-compression": "3.1.26",
+        "@php-wasm/util": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1826,9 +1836,9 @@
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.25.tgz",
-      "integrity": "sha512-v9G6dNAoV/kD+F8z+Yiqia+tUulEDW4mR338VFtSL9GcOjY0Is+ZsMqxQyBauFVz+VLmDQS+Medjz7NBaYRn9A==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.26.tgz",
+      "integrity": "sha512-z7yuMiz2PDeozKfzO0KacXDGKUJA1pA+/8QPeddNuIUekJh4UYDhVfMrySZXjmN3iKupvK1DxWt73a1GDpyFvA==",
       "dev": true,
       "engines": {
         "node": ">=20.10.0",
@@ -1836,14 +1846,15 @@
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.25.tgz",
-      "integrity": "sha512-nDA1A/c9syncdyTrj33i9GrqvD8BXZIiAXpB0Xjnd+SH58VktPVk2A2sjaqsMrdNtokTTkqUsaSTfnrd8Rd8lQ==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.26.tgz",
+      "integrity": "sha512-NBcqgRbjguU9mhDvI2luVcwd4yxMHChUXimItyDb8Es5rwmkS9YyJKIP6Q2XJu3m5n6ZAwtlW2x5OIEW84wmlg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.25",
-        "@php-wasm/universal": "3.1.25",
+        "@php-wasm/scopes": "3.1.26",
+        "@php-wasm/universal": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1852,16 +1863,17 @@
       }
     },
     "node_modules/@php-wasm/xdebug-bridge": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.25.tgz",
-      "integrity": "sha512-dcgGHLl+czz9r/Ymp/r6Z+pySzIt2zZ3o1a6eNMftFrJg7ULJ7CSVQfOOMsN0D4soFnCW77N7gGLsWYl+szf/Q==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.26.tgz",
+      "integrity": "sha512-GBLqoS2Ohj9/51Nfi1gluMo51RUYIY713EmAwSQzYMNgOSvftHrREK+ZBmzO1mROWJypTt1j7qfXv6Px62Uwqw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.25",
-        "@php-wasm/node": "3.1.25",
-        "@php-wasm/universal": "3.1.25",
-        "@wp-playground/common": "3.1.25",
+        "@php-wasm/logger": "3.1.26",
+        "@php-wasm/node": "3.1.26",
+        "@php-wasm/universal": "3.1.26",
+        "@wp-playground/common": "3.1.26",
+        "ajv": "8.12.0",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
@@ -2112,22 +2124,22 @@
       }
     },
     "node_modules/@wp-playground/blueprints": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.25.tgz",
-      "integrity": "sha512-I9bBwMpiXj/3jOD4wMtBS9JauJZe+BDGzALj1W5KydCWtXek9p0BEdFig/0ACl2qtfNwmfOUzenwvJ5WLzIxaw==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.26.tgz",
+      "integrity": "sha512-/A9M/4fzdmorXWBK2CcLTq06dn21EGHiQ5zPw4HsC1Koj2dYn+cUSWaZItdfh9/1d1cfIWvfWEjJs36h67QXow==",
       "dev": true,
       "dependencies": {
-        "@php-wasm/logger": "3.1.25",
-        "@php-wasm/node": "3.1.25",
-        "@php-wasm/progress": "3.1.25",
-        "@php-wasm/scopes": "3.1.25",
-        "@php-wasm/stream-compression": "3.1.25",
-        "@php-wasm/universal": "3.1.25",
-        "@php-wasm/util": "3.1.25",
-        "@php-wasm/web-service-worker": "3.1.25",
-        "@wp-playground/common": "3.1.25",
-        "@wp-playground/storage": "3.1.25",
-        "@wp-playground/wordpress": "3.1.25",
+        "@php-wasm/logger": "3.1.26",
+        "@php-wasm/node": "3.1.26",
+        "@php-wasm/progress": "3.1.26",
+        "@php-wasm/scopes": "3.1.26",
+        "@php-wasm/stream-compression": "3.1.26",
+        "@php-wasm/universal": "3.1.26",
+        "@php-wasm/util": "3.1.26",
+        "@php-wasm/web-service-worker": "3.1.26",
+        "@wp-playground/common": "3.1.26",
+        "@wp-playground/storage": "3.1.26",
+        "@wp-playground/wordpress": "3.1.26",
         "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
@@ -2158,24 +2170,24 @@
       }
     },
     "node_modules/@wp-playground/cli": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.25.tgz",
-      "integrity": "sha512-0Sg4GHwk+afZpYKw6NPhljg5KepDTOK7idgLzZnEDyi7cJMoJiFb45azzKtrW2xYIJFCwmYhNtKeFszovIxZwg==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.26.tgz",
+      "integrity": "sha512-D36l+U2zpz6mymx+i7GnfIV2XI0bKPqv1xXWc2wrXK4ES+GBUFkqm6oWfaemVAptDSYWmPp+hw3EIYn1/0Qtdw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.25",
-        "@php-wasm/logger": "3.1.25",
-        "@php-wasm/node": "3.1.25",
-        "@php-wasm/progress": "3.1.25",
-        "@php-wasm/universal": "3.1.25",
-        "@php-wasm/util": "3.1.25",
-        "@php-wasm/xdebug-bridge": "3.1.25",
-        "@wp-playground/blueprints": "3.1.25",
-        "@wp-playground/common": "3.1.25",
-        "@wp-playground/storage": "3.1.25",
-        "@wp-playground/tools": "3.1.25",
-        "@wp-playground/wordpress": "3.1.25",
+        "@php-wasm/cli-util": "3.1.26",
+        "@php-wasm/logger": "3.1.26",
+        "@php-wasm/node": "3.1.26",
+        "@php-wasm/progress": "3.1.26",
+        "@php-wasm/universal": "3.1.26",
+        "@php-wasm/util": "3.1.26",
+        "@php-wasm/xdebug-bridge": "3.1.26",
+        "@wp-playground/blueprints": "3.1.26",
+        "@wp-playground/common": "3.1.26",
+        "@wp-playground/storage": "3.1.26",
+        "@wp-playground/tools": "3.1.26",
+        "@wp-playground/wordpress": "3.1.26",
         "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
@@ -2208,9 +2220,9 @@
       }
     },
     "node_modules/@wp-playground/client": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-3.1.25.tgz",
-      "integrity": "sha512-XYSyxOcaPcgWEvjySnuVwF3bTn9ihH/JKJ2ix8QlR+fO2tcDQvNNPgEbhUJ5eoe8QrzlVtNEeNbCeQ60Ag7AZQ==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-3.1.26.tgz",
+      "integrity": "sha512-lGx6ouOdfYri9nOAagDljAlXILKcUXuyJolRH6GK1q4J/E9WNeVnedFUELRe91iGX9cc5RbDeyfVqAcTgnhLjw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2219,14 +2231,15 @@
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.25.tgz",
-      "integrity": "sha512-6PizHiLRoczVlJXBtDzLiG1vU85qFR3ddv/2Cn5LApQNphAIC3+qTTXinUrpgslsBPIilVn4Y0CAc6gAHcSsYQ==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.26.tgz",
+      "integrity": "sha512-ROa91YyI75xM5kxYULn4UYbjJ27JvLOxQ5bR1QV1y5PwcS+8J4Zaa/00hdkZJox98DQTzQ2ZT3Vb84j59h9TJQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.25",
-        "@php-wasm/util": "3.1.25",
+        "@php-wasm/universal": "3.1.26",
+        "@php-wasm/util": "3.1.26",
+        "ajv": "8.12.0",
         "ini": "4.1.2"
       },
       "engines": {
@@ -2235,16 +2248,17 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.25.tgz",
-      "integrity": "sha512-PuNkxLKZkE4k92xVRXoat+VqiqWlT8EqsKId104tAOLgLaaQhB+FLD7XEcTgHIaxAdXuAa3XkaOv9R12bHLOEQ==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.26.tgz",
+      "integrity": "sha512-K8F/OmEES8/hMNRfL4+e+OnbSnjAbEiGrbCZ2HWNxQdRkqSCsgf+UVnc1cY7hEWUZUFfE5pvbgCpknCo5aq75A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.25",
-        "@php-wasm/universal": "3.1.25",
-        "@php-wasm/util": "3.1.25",
+        "@php-wasm/stream-compression": "3.1.26",
+        "@php-wasm/universal": "3.1.26",
+        "@php-wasm/util": "3.1.26",
         "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
         "crc-32": "^1.2.0",
@@ -2278,13 +2292,13 @@
       }
     },
     "node_modules/@wp-playground/tools": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.25.tgz",
-      "integrity": "sha512-AN49AChDD8BSBgMthdpBuP/CiqkUZvlWgJC7024hVOMqsZyc3gVI+X2NyxBxe1N5zHERCMA/FWqTvCVl4A6Rtg==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.26.tgz",
+      "integrity": "sha512-4dT/NvwegeD8PJG5/NNIkOpVgsmV2cg3Q1vmyEuDUowbvAuspl5oXSQptsnLK5iZZEc0OPK4J/47/EtxvapHVA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wp-playground/blueprints": "3.1.25",
+        "@wp-playground/blueprints": "3.1.26",
         "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
@@ -2315,17 +2329,18 @@
       }
     },
     "node_modules/@wp-playground/wordpress": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.25.tgz",
-      "integrity": "sha512-RXFu2tMOsqR37T21Yy8XUwEWI0tv98EGtYqHCWj0PCoDq8gCWfofiADs7AF1YVnAI4cgGoeZnsBSsw0gzABy5Q==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.26.tgz",
+      "integrity": "sha512-an5UDOx4fnY83VrS53qf32RGXuNH2QrKgaQPq9jA0SZ5hwXyPcr34NmC16bHPFqWS64q59HvdyrwV3Ts4w6hmA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.25",
-        "@php-wasm/node": "3.1.25",
-        "@php-wasm/universal": "3.1.25",
-        "@php-wasm/util": "3.1.25",
-        "@wp-playground/common": "3.1.25",
+        "@php-wasm/logger": "3.1.26",
+        "@php-wasm/node": "3.1.26",
+        "@php-wasm/universal": "3.1.26",
+        "@php-wasm/util": "3.1.26",
+        "@wp-playground/common": "3.1.26",
+        "ajv": "8.12.0",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",


### PR DESCRIPTION
## Summary

Updated package-lock.json so @wp-playground/blueprints, @wp-playground/cli, @wp-playground/client, and their aligned @php-wasm/@wp-playground transitive packages resolve to 3.1.26.

## Files Changed

package-lock.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm ci; npm ls @wp-playground/blueprints @wp-playground/cli @wp-playground/client --depth=0; npm run lint:js

Resolves #223


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 119,002 tokens on this as a headless worker.